### PR TITLE
Branch te connectivity pull request august31

### DIFF
--- a/CFX/Production/Assembly/PressInsertion/ConditionCompleted.cs
+++ b/CFX/Production/Assembly/PressInsertion/ConditionCompleted.cs
@@ -23,7 +23,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using CFX;
 using CFX.Structures;
-
+using CFX.Structures.PressInsertion;
 
 namespace CFX.Production.Assembly.PressInsertion
 {
@@ -32,6 +32,7 @@ namespace CFX.Production.Assembly.PressInsertion
     /// <code language="none">
     /// {
     ///   "TransactionID": "2c24590d-39c5-4039-96a5-91900cecedfa",
+    ///	  "ConditionName" "Condition1",
     ///   "ResultOfCondition": Success,
     ///   "UnitPosition": 
     ///     {
@@ -57,6 +58,15 @@ namespace CFX.Production.Assembly.PressInsertion
             get;
             set;
         }
+
+	/// <summary>
+        /// Identifies the Condition name
+        /// </summary>
+	public ConditionName ConditionName
+	{
+	    get;
+	    set;
+	}
 
         /// <summary>
         /// Identifies the related production unit

--- a/CFX/Production/Assembly/PressInsertion/ConditionStarted.cs
+++ b/CFX/Production/Assembly/PressInsertion/ConditionStarted.cs
@@ -23,7 +23,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using CFX;
 using CFX.Structures;
-
+using CFX.Structures.PressInsertion;
 
 namespace CFX.Production.Assembly.PressInsertion
 {
@@ -36,6 +36,7 @@ namespace CFX.Production.Assembly.PressInsertion
     /// <code language="none">
     /// {
     ///   "TransactionID": "2c24590d-39c5-4039-96a5-91900cecedfa",
+    ///   "ConditionName" "Condition1",
     ///   "UnitPosition": 
     ///     {
     ///       "UnitIdentifier": "CARRIER5566",
@@ -60,6 +61,14 @@ namespace CFX.Production.Assembly.PressInsertion
             get;
             set;
         }
+	/// <summary>
+        /// Identifies the Condition name
+        /// </summary>
+	public ConditionName ConditionName
+	{
+	    get;
+	    set;
+	}
         /// <summary>
         /// Identifies the related production unit
         /// </summary>

--- a/CFX/Production/Assembly/PressInsertion/ConditionStarted.cs
+++ b/CFX/Production/Assembly/PressInsertion/ConditionStarted.cs
@@ -28,11 +28,14 @@ using CFX.Structures;
 namespace CFX.Production.Assembly.PressInsertion
 {
     /// <summary>
-    /// Sent by a press insertion machine when a condition has been completed
+    /// Sent by a press insertion machine when a condition has been started
+    /// A condition is a physical or logical operation - i.e. A pin insertion or connector press onto a board
+    /// is a physical condition, much like a validation of a part before a connector insertion occurs is a 
+    /// logical condition
+    /// 
     /// <code language="none">
     /// {
     ///   "TransactionID": "2c24590d-39c5-4039-96a5-91900cecedfa",
-    ///   "ResultOfCondition": Success,
     ///   "UnitPosition": 
     ///     {
     ///       "UnitIdentifier": "CARRIER5566",
@@ -57,20 +60,10 @@ namespace CFX.Production.Assembly.PressInsertion
             get;
             set;
         }
-
         /// <summary>
         /// Identifies the related production unit
         /// </summary>
 	public UnitPosition UnitPosition
-        {
-            get;
-            set;
-        }
-        
-        /// <summary>
-        /// Identifies the result of the condition
-        /// </summary>
-	public StatusResult ResultOfCondition
         {
             get;
             set;

--- a/CFX/Production/Assembly/PressInsertion/GetConditionPermissionRequest.cs
+++ b/CFX/Production/Assembly/PressInsertion/GetConditionPermissionRequest.cs
@@ -28,6 +28,7 @@ namespace CFX.Production.Assembly.PressInsertion
     /// <code language="none">
     /// {
     ///   "TransactionId": "7e712504-4d65-499f-9dcb-1974e20bae59",
+    ///   "ConditionName" "Condition1",
     ///   "ConditionStep": {}
     ///   "Data": {}
     /// }
@@ -49,6 +50,15 @@ namespace CFX.Production.Assembly.PressInsertion
             get;
             set;
         }
+
+	/// <summary>
+        /// Identifies the Condition name
+        /// </summary>
+	public ConditionName ConditionName
+	{
+	    get;
+	    set;
+}	
 
 	/// <summary>	
     	/// Describes a individual step of a Condition sequence that must be validated

--- a/CFX/Production/Assembly/PressInsertion/GetConditionPermissionResponse.cs
+++ b/CFX/Production/Assembly/PressInsertion/GetConditionPermissionResponse.cs
@@ -33,6 +33,7 @@ namespace CFX.Production.Assembly.PressInsertion
     ///     "Message": null
     ///   },
     ///   "TransactionId": "7e712504-4d65-499f-9dcb-1974e20bae59",
+    ///   "ConditionName" "Condition1",
     ///   "ConditionStep": {}
     /// }
     /// </code>
@@ -52,6 +53,15 @@ namespace CFX.Production.Assembly.PressInsertion
             get;
             set;
         }
+
+	/// <summary>
+        /// Identifies the Condition name
+        /// </summary>
+	public ConditionName ConditionName
+	{
+	    get;
+	    set;
+	}
 
         /// <summary>	
         /// Describes a individual step of a Condition sequence that must be validated


### PR DESCRIPTION
A Condition can refer to either a physical insertion/press or a logical operation (like validating a user).  A condition may contain multiple “condition steps”
 
Our changes address the “linking up” of these messages to the actual conditions that they pertain to.  In other words:
 
To go along with the “ConditionCompleted” message we added a “ConditionStarted” message.
 
Both messages now reference a “ConditionName” and “UnitPosition”. “ConditionName” simply states the particular condition (string – not object)  that has either started or completed, while the “UnitsPosition” is a structure defined in the CFX spec to uniquely identify a Panel and/or an individual PCB in the panel.  This way a board may have a bunch of conditions, some relating to actual insertions/presses others to only logical ones.
 
In any event, the ConditionStarted/ConditionCompleted messages simply means that the referenced “Condition” for a particular PCB (that may be one of X in a panel) has either Started or Completed for a given Transaction ID.
 
Along the same line of thinking – we added the “ConditionName” to the existing request/response for “GetConditionPermission[Request/Response].  This message though operates on the level of a “Condition Step” whereas the ConditionStarted/ConditionCompleted operate on the overall condition.