### PR TITLE
Add PrimaryIdentifier and HermesIdentifier to a couple of messages

### DIFF
--- a/CFX/InformationSystem/UnitValidation/ValidateUnitsRequest.cs
+++ b/CFX/InformationSystem/UnitValidation/ValidateUnitsRequest.cs
@@ -72,6 +72,24 @@ namespace CFX.InformationSystem.UnitValidation
         }
 
         /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// List of structures that identify each specific instance of production unit that arrived (could be within a carrier or panel). 
         /// </summary>
         public List<UnitPosition> Units

--- a/CFX/Production/UnitsArrived.cs
+++ b/CFX/Production/UnitsArrived.cs
@@ -43,6 +43,38 @@ namespace CFX.Production
         }
 
         /// <summary>
+        /// The barcode, RFID, etc. that was most recently acquired by the scanner / reader.  If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// </summary>
+        public string PrimaryIdentifier
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+
+
+        /// <summary>
         /// The number of individual production units
         /// </summary>
         public int UnitCount

--- a/CFX/Production/UnitsDeparted.cs
+++ b/CFX/Production/UnitsDeparted.cs
@@ -44,6 +44,37 @@ namespace CFX.Production
         }
 
         /// <summary>
+        /// The barcode, RFID, etc. that was most recently acquired by the scanner / reader.  If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// </summary>
+        public string PrimaryIdentifier
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+
+        /// <summary>
         /// The number of individual production units
         /// </summary>
         public int UnitCount

--- a/CFX/Production/UnitsDisqualified.cs
+++ b/CFX/Production/UnitsDisqualified.cs
@@ -48,6 +48,36 @@ namespace CFX.Production
         }
 
         /// <summary>
+        /// The barcode, RFID, etc. that was most recently acquired by the scanner / reader.  If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// </summary>
+        public string PrimaryIdentifier
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The reason why these units are being disqualified (scrapped).
         /// </summary>
         public DisqualificationReason Reason

--- a/CFX/Production/UnitsInitialized.cs
+++ b/CFX/Production/UnitsInitialized.cs
@@ -50,6 +50,36 @@ namespace CFX.Production
         }
 
         /// <summary>
+        /// The barcode, RFID, etc. that was most recently acquired by the scanner / reader.  If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// </summary>
+        public string PrimaryIdentifier
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The Work Order (and Batch, if applicable) to which these new production units are associated.
         /// </summary>
         public WorkOrderIdentifier WorkOrderIdentifier

--- a/CFX/Production/WorkStarted.cs
+++ b/CFX/Production/WorkStarted.cs
@@ -49,6 +49,36 @@ namespace CFX.Production
         }
 
         /// <summary>
+        /// The barcode, RFID, etc. that was most recently acquired by the scanner / reader.  If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// </summary>
+        public string PrimaryIdentifier
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Transaction ID used to attach events and data during subsequent processing, until WorkCompleted
         /// </summary>
         public Guid TransactionID

--- a/CFX/Sensor/Identification/IdentifiersRead.cs
+++ b/CFX/Sensor/Identification/IdentifiersRead.cs
@@ -58,6 +58,24 @@ namespace CFX.Sensor.Identification
         }
 
         /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// An optional list of actual production unit identifiers, in the case that multiple production units are moving through the 
         /// process, and the sensor is capable if reading multiple identifiers. 
         /// </summary>

--- a/CFX/Sensor/Identification/IdentifyUnitsResponse.cs
+++ b/CFX/Sensor/Identification/IdentifyUnitsResponse.cs
@@ -71,6 +71,24 @@ namespace CFX.Sensor.Identification
         }
 
         /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// An optional list of actual production unit identifiers, in the case that multiple production units are moving through the 
         /// process, and the sensor is capable if reading multiple identifiers. 
         /// </summary>

--- a/CFX/Structures/PressInsertion/ConditionResult.cs
+++ b/CFX/Structures/PressInsertion/ConditionResult.cs
@@ -36,6 +36,36 @@ namespace CFX.Structures.PressInsertion
             ConditionOperator = new Operator();
         }
 
+        /// <summary>
+        /// The barcode, RFID, etc. that was most recently acquired by the scanner / reader.  If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// </summary>
+        public string PrimaryIdentifier
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The Hermes BoardId of the carrier, a PCB panel or single production unit. If a single production unit is moving through the
+        /// process, this would be the actual unique identifier of that individual unition unit.  However, if multiple production units are moving
+        /// through the process as a group (as in the case of a PCB panel, a fixture, or any sort of carrier), this would be an identifier that
+        /// represents the entire group of units, such as a carrier UID, a PCB panel UID, etc.
+        /// HermesIdentifier will be transfered between all machines which support Hermes. The PrimaryIdentifier is containing a barcode information.
+        /// Both can be transferred.
+        /// <remarks>
+        /// Espcially when the line does not support the Hermes standard in the hole line, the Hermes Identifier can be unique only in the a part
+        /// of the line. The Primary Identifier can be used to correlate the parts of hermes sublines to correlate this data as well. 
+        /// </remarks>
+        /// </summary>
+        public string HermesIdentifier 
+        {
+            get;
+            set;
+        }
+
 
         /// <summary>
         /// Transaction ID used to attach events and data during subsequent processing, until WorkCompleted

--- a/CFXExampleEndpoint/AsmTesting.cs
+++ b/CFXExampleEndpoint/AsmTesting.cs
@@ -33,6 +33,7 @@ namespace CFXExampleEndpoint
             WorkStarted ws = new WorkStarted()
             {
                 TransactionID = tid,
+                
                 Units = new UnitPosition[]
                 {
                     new UnitPosition() { PositionName = "1", PositionNumber = 1, UnitIdentifier = "PANEL_SERIALNUM_1234567"},

--- a/CFXExampleEndpoint/CFXExampleEndpoint.csproj
+++ b/CFXExampleEndpoint/CFXExampleEndpoint.csproj
@@ -38,6 +38,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/CFXExampleEndpoint/CFXExampleGenerator.cs
+++ b/CFXExampleEndpoint/CFXExampleGenerator.cs
@@ -32,7 +32,7 @@ using CFX.ResourcePerformance.THTInsertion;
 using CFX.Production.Application.Solder;
 using CFX.Production.Processing;
 using CFX.Structures.Coating;
-using CFX.Structures.ReflowProfiling;
+//using CFX.Structures.ReflowProfiling;
 
 namespace CFXExampleEndpoint
 {


### PR DESCRIPTION
Add PrimaryIdentifier and HermesIdentifier to a couple of messages
Provide the ability to report a Panel Barocde to a couple of messages with PrimaryIdentifier 
as well as add an additional HermesIdentifier  to report he Hermes BoardID as well