### PR TITLE
Fix of a bug when using SMTInstalledMaterial

### DIFF
--- a/CFX/Structures/InstalledMaterial.cs
+++ b/CFX/Structures/InstalledMaterial.cs
@@ -66,6 +66,7 @@ namespace CFX.Structures
         /// <summary>
         /// A list of where the on the production unit the materials / parts were installed.
         /// </summary>
+        [JsonProperty(ItemTypeNameHandling = TypeNameHandling.Auto)]
         public List<InstalledComponent> InstalledComponents
         {
             get;
@@ -75,6 +76,7 @@ namespace CFX.Structures
 		/// <summary>
         /// A list of where the on the production unit the materials / parts were not installed.
         /// </summary>
+        [JsonProperty(ItemTypeNameHandling = TypeNameHandling.Auto)]
         public List<NonInstalledComponent> NonInstalledComponents
         {
             get;


### PR DESCRIPTION
“JsonProperties” are missing for auto name handling in InstalledMaterial. The consequence is that when we send a structure that inherits from it (SMTInstalled material i.e), the receiver receives the InstallMaterial structure instead.


