### PR TITLE
Added support for depaneling process

### DIFF
--- a/CFX/InformationSystem/UnitValidation/ValidateUnitsRequest.cs
+++ b/CFX/InformationSystem/UnitValidation/ValidateUnitsRequest.cs
@@ -100,5 +100,20 @@ namespace CFX.InformationSystem.UnitValidation
             get;
             set;
         }
+
+        /// <summary>
+        /// Lane identifier.  Null if no specific lane
+        /// </summary>
+        /// <remarks>
+        /// This field allows distinguishing between requests when different kinds of units enter the machine and all need to be validated.
+        /// For instance, a depaneling cell where both panels and carriers would need to be validated.
+        /// - The panel has a data matrix for id and a set of modules whose statuses need to be validated.
+        /// - The carrier (pallet, fixture, tray, etc) has a data matrix for id and a set of nests whose statuses need to be validated.
+        /// </remarks>
+        public int? Lane
+        {
+            get;
+            set;
+        }
     }
 }

--- a/CFX/Production/LoadingAndUnloading/UnitsLoaded.cs
+++ b/CFX/Production/LoadingAndUnloading/UnitsLoaded.cs
@@ -8,8 +8,7 @@ using CFX.Structures;
 namespace CFX.Production.LoadingAndUnloading
 {
     /// <summary>
-    /// Sent when a unit is unloaded into any form of carrier, including fixtures, pallets, trays, tubs, totes, carts, etc.
-    /// Associates unit with a carrier.
+    /// Sent when a unit is loaded from any form of carrier, including fixtures, pallets, trays, tubs, totes, carts, etc.
     /// <code language="none">
     /// {
     ///   "UniqueIdentifier": "PALLET123",
@@ -38,12 +37,12 @@ namespace CFX.Production.LoadingAndUnloading
     /// }
     /// </code>
     /// </summary>
-    public class UnitsUnloaded : CFXMessage
+    public class UnitsLoaded : CFXMessage
     {
         /// <summary>
         /// Default constructor.
         /// </summary>
-        public UnitsUnloaded()
+        public UnitsLoaded()
         {
             Units = new List<UnitPosition>();
         }
@@ -58,7 +57,7 @@ namespace CFX.Production.LoadingAndUnloading
         }
 
         /// <summary>
-        /// A list of the specific units that were unloaded along with positions they were unloaded to.
+        /// A list of the specific units that were loaded along with positions they were loaded from.
         /// </summary>
         public List<UnitPosition> Units
         {

--- a/CFX/Production/LoadingAndUnloading/UnitsUnloaded.cs
+++ b/CFX/Production/LoadingAndUnloading/UnitsUnloaded.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CFX.Structures;
+
+namespace CFX.Production.LoadingAndUnloading
+{
+    /// <summary>
+    /// Sent when a unit is unloaded into any form of carrier, including fixtures, pallets, trays, tubs, totes, carts, etc.
+    /// Associates unit with a carrier.
+    /// <code language="none">
+    /// {
+    ///   "UniqueIdentifier": "PALLET123",
+    ///   "Units": [
+    ///     {
+    ///       "UnitIdentifier": "MODULE1",
+    ///       "PositionNumber": 1,
+    ///       "PositionName": "NEST1",
+    ///       "X": 50.45,
+    ///       "Y": 80.66,
+    ///       "Rotation": 0.0,
+    ///       "FlipX": false,
+    ///       "FlipY": false
+    ///     },
+    ///     {
+    ///       "UnitIdentifier": "MODULE2",
+    ///       "PositionNumber": 2,
+    ///       "PositionName": "NEST2",
+    ///       "X": 70.45,
+    ///       "Y": 80.66,
+    ///       "Rotation": 0.0,
+    ///       "FlipX": false,
+    ///       "FlipY": false
+    ///     }
+    ///   ]
+    /// }
+    /// </code>
+    /// </summary>
+    public class UnitsUnloaded : CFXMessage
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public UnitsUnloaded()
+        {
+            Units = new List<UnitPosition>();
+        }
+
+        /// <summary>
+        /// The unique identifier for this carrier (barcode, RFID, etc.)
+        /// </summary>
+        public string UniqueIdentifier
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A list of the specific materials which were applied.
+        /// </summary>
+        public List<UnitPosition> Units
+        {
+            get;
+            set;
+        }
+    }
+}


### PR DESCRIPTION
The proposal addresses two missing aspects in depaneling process: carrier validation and association of units with the carrier.

1. Carrier validation can already be done with ValidateUnitsRequest/Response but since it's also used for panel validation there is ambiguity between the messages. The proposal adds a Lane identifier field to the request.

2. Unit-Carrier association should be done with the upcoming CFX.Production.LoadingAndUnloading.UnitsUnloaded message. As we did not have the existing proposal for this message at hand this pull request proposes our own for consideration. We need two arguments: a carrier identifier (DMC) and a list of units that are placed into the carrier.
