### PR TITLE
Do _not_ set CFXEnvelope.Version to the version of the CFX-DLL in Mes…

### DIFF
--- a/CFX/CFXEnvelope.cs
+++ b/CFX/CFXEnvelope.cs
@@ -45,7 +45,7 @@ namespace CFX
             Transmitted = false;
         }
 
-        public const string CFXVERSION = "1.2";
+        public const string CFXVERSION = "1.3";
         
         public CFXEnvelope(Type messageType) : this()
         {

--- a/CFX/CFXEnvelope.cs
+++ b/CFX/CFXEnvelope.cs
@@ -169,7 +169,6 @@ namespace CFX
                 if (messageBody != null && MessageBody.GetType().FullName.StartsWith("CFX."))
                 {
                     MessageName = messageBody.GetType().FullName;
-                    Version = CFXVERSION;
                 }
             }
         }


### PR DESCRIPTION
…sageBody.set, as that, when receiving a CFX message, overwrites the actual version of the sender (with CFXVERSION of the receiving CFX-DLL).

When sending a CFX message the Version is initialized correctly (to CFXVERSION of the sending CFX-DLL) in the constructor of CFXEnvelope anyway.