### PR TITLE
Hermes integration extension for CFX 1.3

### DIFF
--- a/CFX/Production/Hermes/GetMagazineDataRequest.cs
+++ b/CFX/Production/Hermes/GetMagazineDataRequest.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.Hermes
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.3 **</para>
+    /// Sent from a Hermes endpoint to request magazine data
+    /// <code language="none">
+    /// {
+    ///   "MagazineId": "ID12345"
+    /// }
+    /// </code>
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("1.3")]
+    public class GetMagazineDataRequest : CFXMessage
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public GetMagazineDataRequest()
+        {
+        
+        }
+
+        /// <summary>
+        /// Barcode of a magazine, required to identify the magazine.
+        /// </summary>
+        public string MagazineId
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Production/Hermes/GetMagazineDataResponse.cs
+++ b/CFX/Production/Hermes/GetMagazineDataResponse.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.Hermes
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.3 **</para>
+    /// Reponse to a request by a Hermes enabled endpoint to acquire information related to a particular magazine.
+    /// <code language="none">
+    /// {
+    ///   "Result": {
+    ///     "Result": "Success",
+    ///     "ResultCode": 0,
+    ///     "Message": null
+    ///   },
+    ///   "MagazineData": {
+    ///     "MagazineId": "ID12345",
+    ///     "HermesUnits": [
+    ///       {
+    ///         "SlotId": 1,
+    ///         "BoardId": "3ce1c3f6-695d-4eaa-a0eb-cadb9b1eccba",
+    ///         "BoardIdCreatedBy": "Printer12345",
+    ///         "FailedBoard": 1,
+    ///         "ProductTypeId": "Product_A",
+    ///         "FlippedBoard": 1,
+    ///         "TopBarcode": "BT_M20206500001",
+    ///         "BottomBarcode": "B_M20206500001",
+    ///         "Lenght": 160.0,
+    ///         "Width": 100.0,
+    ///         "Thickness": 10.0,
+    ///         "ConveyorSpeed": 1200.0,
+    ///         "TopClearanceHeight": 2.5,
+    ///         "BottomClearanceHeight": 1.2,
+    ///         "Weight": 80.0,
+    ///         "WorkOrderIdentifier": {
+    ///           "WorkOrderId": "WO9988776666",
+    ///           "Batch": "Batch1"
+    ///         }
+    ///       },
+    ///       {
+    ///         "SlotId": 2,
+    ///         "BoardId": "67ec444b-24de-4ed3-b7be-1db4ace6ef5f",
+    ///         "BoardIdCreatedBy": "Printer12345",
+    ///         "FailedBoard": 1,
+    ///         "ProductTypeId": "Product_A",
+    ///         "FlippedBoard": 1,
+    ///         "TopBarcode": "BT_M20206500002",
+    ///         "BottomBarcode": "B_M20206500002",
+    ///         "Lenght": 160.0,
+    ///         "Width": 100.0,
+    ///         "Thickness": 10.0,
+    ///         "ConveyorSpeed": 1200.0,
+    ///         "TopClearanceHeight": 2.5,
+    ///         "BottomClearanceHeight": 1.2,
+    ///         "Weight": 80.0,
+    ///         "WorkOrderIdentifier": {
+    ///           "WorkOrderId": "WO9988776666",
+    ///           "Batch": "Batch1"
+    ///         }
+    ///       }
+    ///     ]
+    ///   }
+    /// }
+    /// </code>
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("1.3")]
+    public class GetMagazineDataResponse : CFXMessage
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public GetMagazineDataResponse()
+        {
+        
+        }
+
+        /// <summary>
+        /// Result of the request
+        /// </summary>
+        public RequestResult Result
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Barcode of a magazine, required to identify the magazine.
+        /// </summary>
+        public Magazine MagazineData
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Production/Hermes/MagazineArrived.cs
+++ b/CFX/Production/Hermes/MagazineArrived.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.Hermes
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.3 **</para>
+    /// Event triggered by a Hermes enabled endpoint when a magazine arrived.
+    /// <code language="none">
+    /// {
+    ///   "MagazineData": {
+    ///     "MagazineId": "ID12345",
+    ///     "HermesUnits": [
+    ///       {
+    ///         "SlotId": 1,
+    ///         "BoardId": "aa40cd8e-aa68-4ce5-a1dd-a8c41bd3fa9c",
+    ///         "BoardIdCreatedBy": "Printer12345",
+    ///         "FailedBoard": 1,
+    ///         "ProductTypeId": "Product_A",
+    ///         "FlippedBoard": 1,
+    ///         "TopBarcode": "BT_M20206500001",
+    ///         "BottomBarcode": "B_M20206500001",
+    ///         "Lenght": 160.0,
+    ///         "Width": 100.0,
+    ///         "Thickness": 10.0,
+    ///         "ConveyorSpeed": 1200.0,
+    ///         "TopClearanceHeight": 2.5,
+    ///         "BottomClearanceHeight": 1.2,
+    ///         "Weight": 80.0,
+    ///         "WorkOrderIdentifier": {
+    ///           "WorkOrderId": "WO9988776666",
+    ///           "Batch": "Batch1"
+    ///         }
+    ///       },
+    ///       {
+    ///         "SlotId": 2,
+    ///         "BoardId": "7eb2a1db-5adf-4582-8508-180320158178",
+    ///         "BoardIdCreatedBy": "Printer12345",
+    ///         "FailedBoard": 1,
+    ///         "ProductTypeId": "Product_A",
+    ///         "FlippedBoard": 1,
+    ///         "TopBarcode": "BT_M20206500002",
+    ///         "BottomBarcode": "B_M20206500002",
+    ///         "Lenght": 160.0,
+    ///         "Width": 100.0,
+    ///         "Thickness": 10.0,
+    ///         "ConveyorSpeed": 1200.0,
+    ///         "TopClearanceHeight": 2.5,
+    ///         "BottomClearanceHeight": 1.2,
+    ///         "Weight": 80.0,
+    ///         "WorkOrderIdentifier": {
+    ///           "WorkOrderId": "WO9988776666",
+    ///           "Batch": "Batch1"
+    ///         }
+    ///       }
+    ///     ]
+    ///   }
+    /// }
+    /// </code>
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("1.3")]
+    public class MagazineArrived : CFXMessage
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public MagazineArrived()
+        {
+        
+        }
+
+        /// <summary>
+        /// Barcode of a magazine, required to identify the magazine.
+        /// </summary>
+        public Magazine MagazineData
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Production/Hermes/MagazineDeparted.cs
+++ b/CFX/Production/Hermes/MagazineDeparted.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.Hermes
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.3 **</para>
+    /// Event triggered by a Hermes enabled endpoint when a magazine departed.
+    /// <code language="none">
+    /// {
+    ///   "MagazineData": {
+    ///     "MagazineId": "ID12345",
+    ///     "HermesUnits": [
+    ///       {
+    ///         "SlotId": 1,
+    ///         "BoardId": "cb8de687-00a1-48a8-a869-314e64cf0e86",
+    ///         "BoardIdCreatedBy": "Printer12345",
+    ///         "FailedBoard": 1,
+    ///         "ProductTypeId": "Product_A",
+    ///         "FlippedBoard": 1,
+    ///         "TopBarcode": "BT_M20206500001",
+    ///         "BottomBarcode": "B_M20206500001",
+    ///         "Lenght": 160.0,
+    ///         "Width": 100.0,
+    ///         "Thickness": 10.0,
+    ///         "ConveyorSpeed": 1200.0,
+    ///         "TopClearanceHeight": 2.5,
+    ///         "BottomClearanceHeight": 1.2,
+    ///         "Weight": 80.0,
+    ///         "WorkOrderIdentifier": {
+    ///           "WorkOrderId": "WO9988776666",
+    ///           "Batch": "Batch1"
+    ///         }
+    ///       },
+    ///       {
+    ///         "SlotId": 2,
+    ///         "BoardId": "4aafb669-eec8-4b7d-b436-641f59bf0529",
+    ///         "BoardIdCreatedBy": "Printer12345",
+    ///         "FailedBoard": 1,
+    ///         "ProductTypeId": "Product_A",
+    ///         "FlippedBoard": 1,
+    ///         "TopBarcode": "BT_M20206500002",
+    ///         "BottomBarcode": "B_M20206500002",
+    ///         "Lenght": 160.0,
+    ///         "Width": 100.0,
+    ///         "Thickness": 10.0,
+    ///         "ConveyorSpeed": 1200.0,
+    ///         "TopClearanceHeight": 2.5,
+    ///         "BottomClearanceHeight": 1.2,
+    ///         "Weight": 80.0,
+    ///         "WorkOrderIdentifier": {
+    ///           "WorkOrderId": "WO9988776666",
+    ///           "Batch": "Batch1"
+    ///         }
+    ///       }
+    ///     ]
+    ///   }
+    /// }
+    /// </code>
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("1.3")]
+    public class MagazineDeparted : CFXMessage
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public MagazineDeparted()
+        {
+        
+        }
+
+        /// <summary>
+        /// Barcode of a magazine, required to identify the magazine.
+        /// </summary>
+        public Magazine MagazineData
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/HermesUnit.cs
+++ b/CFX/Structures/HermesUnit.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace CFX.Structures
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.3 **</para>
+    /// Structure that contains information related to a Unit (Board) according to the Hermes standard.
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("1.3")]
+    [JsonObject(ItemTypeNameHandling = TypeNameHandling.Auto)]
+    public class HermesUnit
+    {
+        /// <summary>
+        /// Indicates the slot in the magazine, enumerated from bottom to top, beginning with 1.
+        /// </summary>
+        public int SlotId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Indicating the ID of the available board (GUID, 36 bytes)
+        /// </summary>
+        public string BoardId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// MachineId of the machine which created the BoardId 
+        /// (the first machine in a consecutive row of machines implementing this protocol). 
+        /// The MachineId is part of the Hermes configuration.
+        /// </summary>
+        public string BoardIdCreatedBy
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A value of the list below.
+        /// 0	Board of unknown quality available
+        /// 1	Good board available
+        /// 2	Failed board available
+
+        /// </summary>
+        public int FailedBoard
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Identifies a collection of printed boards sharing common properties.
+        /// </summary>
+        public string ProductTypeId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A value of the list below:
+        /// 0	Side up is unknown
+        /// 1	Board top side is up
+        /// 2	Board bottom side is up
+
+        /// </summary>
+        public int FlippedBoard
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The barcode of the top side of the printed board.
+        /// </summary>
+        public string TopBarcode
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The barcode of the bottom side of the printed board.
+        /// </summary>
+        public string BottomBarcode
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The length of the printed board in millimeter.
+        /// </summary>
+        public double? Lenght
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The width of the printed board in millimeter.
+        /// </summary>
+        public double? Width
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The thickness of the printed board in millimeter.
+        /// </summary>
+        public double? Thickness
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The conveyor speed preferred by the upstream machine in millimeter per second.
+        /// </summary>
+        public double? ConveyorSpeed
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The clearance height for the top side of the printed board in millimeter.
+        /// </summary>
+        public double? TopClearanceHeight
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The clearance height for the bottom side of the printed board in millimeter.
+        /// </summary>
+        public double? BottomClearanceHeight
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The weight of the printed board in grams.
+        /// </summary>
+        public double? Weight
+        {
+            get;
+            set;
+        }
+        /// <summary>
+        /// Identifier of the Work Order (Batch and ID).
+        /// </summary>
+        public WorkOrderIdentifier WorkOrderIdentifier
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/Magazine.cs
+++ b/CFX/Structures/Magazine.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CFX.Structures
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.3 **</para>
+    /// Structure that contains information related to a magazine.
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("1.3")]
+    public class Magazine
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Magazine()
+        {
+
+        }
+        /// <summary>
+        /// Barcode of a magazine, required to identify the magazine.
+        /// </summary>
+        public string MagazineId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// List of Hermes units (i.e. Boards) contained in the magazine.
+        /// </summary>
+        public List<HermesUnit> HermesUnits
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFXExampleEndpoint/CFXExampleGenerator.cs
+++ b/CFXExampleEndpoint/CFXExampleGenerator.cs
@@ -33,6 +33,7 @@ using CFX.Production.Application.Solder;
 using CFX.Production.Processing;
 using CFX.Structures.Coating;
 using CFX.Structures.ReflowProfiling;
+using CFX.Production.Hermes;
 
 namespace CFXExampleEndpoint
 {
@@ -4107,6 +4108,191 @@ namespace CFXExampleEndpoint
 
             msg = new HandleFaultResponse()
             {
+            };
+            AppendMessage(msg, ref result);
+
+            //New CFX 1.3 Proposal for Hermes Magazine management
+            msg = new GetMagazineDataRequest()
+            {
+                MagazineId = "ID12345"
+            };
+            AppendMessage(msg, ref result);
+
+            msg = new GetMagazineDataResponse()
+            {
+               Result = new RequestResult()
+               {
+                   
+               },
+               MagazineData = new Magazine()
+               {
+                   MagazineId = "ID12345",
+                   HermesUnits = new List<HermesUnit>()
+                   {
+                       new HermesUnit()
+                       {
+                           BoardId =Guid.NewGuid().ToString(),
+                           BoardIdCreatedBy = "Printer12345",
+                           BottomBarcode = "B_M20206500001",
+                           TopBarcode = "BT_M20206500001",
+                           BottomClearanceHeight = 1.2,
+                           ConveyorSpeed = 1200,
+                           Lenght = 160,
+                           SlotId = 1,
+                           TopClearanceHeight = 2.5,
+                           Width = 100,
+                           Thickness = 10,
+                           Weight = 80,
+                           FailedBoard = 1,
+                           FlippedBoard = 1,
+                           ProductTypeId = "Product_A",
+                           WorkOrderIdentifier = new WorkOrderIdentifier()
+                           {
+                                WorkOrderId = "WO9988776666",
+                                Batch = "Batch1"
+                           }
+                       },
+                       new HermesUnit()
+                       {
+                           BoardId = Guid.NewGuid().ToString(),
+                           BoardIdCreatedBy = "Printer12345",
+                           BottomBarcode = "B_M20206500002",
+                           TopBarcode = "BT_M20206500002",
+                           BottomClearanceHeight = 1.2,
+                           ConveyorSpeed = 1200,
+                           Lenght = 160,
+                           SlotId = 2,
+                           TopClearanceHeight = 2.5,
+                           Width = 100,
+                           Thickness = 10,
+                           Weight = 80,
+                           FailedBoard = 1,
+                           FlippedBoard = 1,
+                           ProductTypeId = "Product_A",
+                           WorkOrderIdentifier = new WorkOrderIdentifier()
+                           {
+                                WorkOrderId = "WO9988776666",
+                                Batch = "Batch1"
+                           }
+                       }
+                   }
+               }
+            };
+            AppendMessage(msg, ref result);
+
+            msg = new MagazineArrived()
+            {
+                MagazineData = new Magazine()
+                {
+                    MagazineId = "ID12345",
+                    HermesUnits = new List<HermesUnit>()
+                    {
+                       new HermesUnit()
+                       {
+                           BoardId = Guid.NewGuid().ToString(),
+                           BoardIdCreatedBy = "Printer12345",
+                           BottomBarcode = "B_M20206500001",
+                           TopBarcode = "BT_M20206500001",
+                           BottomClearanceHeight = 1.2,
+                           ConveyorSpeed = 1200,
+                           Lenght = 160,
+                           SlotId = 1,
+                           TopClearanceHeight = 2.5,
+                           Width = 100,
+                           Thickness = 10,
+                           Weight = 80,
+                           FailedBoard = 1,
+                           FlippedBoard = 1,
+                           ProductTypeId = "Product_A",
+                           WorkOrderIdentifier = new WorkOrderIdentifier()
+                           {
+                                WorkOrderId = "WO9988776666",
+                                Batch = "Batch1"
+                           }
+                       },
+                       new HermesUnit()
+                       {
+                           BoardId = Guid.NewGuid().ToString(),
+                           BoardIdCreatedBy = "Printer12345",
+                           BottomBarcode = "B_M20206500002",
+                           TopBarcode = "BT_M20206500002",
+                           BottomClearanceHeight = 1.2,
+                           ConveyorSpeed = 1200,
+                           Lenght = 160,
+                           SlotId = 2,
+                           TopClearanceHeight = 2.5,
+                           Width = 100,
+                           Thickness = 10,
+                           Weight = 80,
+                           FailedBoard = 1,
+                           FlippedBoard = 1,
+                           ProductTypeId = "Product_A",
+                           WorkOrderIdentifier = new WorkOrderIdentifier()
+                           {
+                                WorkOrderId = "WO9988776666",
+                                Batch = "Batch1"
+                           }
+                       }
+                   }
+                }
+            };
+            AppendMessage(msg, ref result);
+            
+            msg = new MagazineDeparted()
+            {
+                MagazineData = new Magazine()
+                {
+                    MagazineId = "ID12345",
+                    HermesUnits = new List<HermesUnit>()
+                    {
+                       new HermesUnit()
+                       {
+                           BoardId = Guid.NewGuid().ToString(),
+                           BoardIdCreatedBy = "Printer12345",
+                           BottomBarcode = "B_M20206500001",
+                           TopBarcode = "BT_M20206500001",
+                           BottomClearanceHeight = 1.2,
+                           ConveyorSpeed = 1200,
+                           Lenght = 160,
+                           SlotId = 1,
+                           TopClearanceHeight = 2.5,
+                           Width = 100,
+                           Thickness = 10,
+                           Weight = 80,
+                           FailedBoard = 1,
+                           FlippedBoard = 1,
+                           ProductTypeId = "Product_A",
+                           WorkOrderIdentifier = new WorkOrderIdentifier()
+                           {
+                                WorkOrderId = "WO9988776666",
+                                Batch = "Batch1"
+                           }
+                       },
+                       new HermesUnit()
+                       {
+                           BoardId = Guid.NewGuid().ToString(),
+                           BoardIdCreatedBy = "Printer12345",
+                           BottomBarcode = "B_M20206500002",
+                           TopBarcode = "BT_M20206500002",
+                           BottomClearanceHeight = 1.2,
+                           ConveyorSpeed = 1200,
+                           Lenght = 160,
+                           SlotId = 2,
+                           TopClearanceHeight = 2.5,
+                           Width = 100,
+                           Thickness = 10,
+                           Weight = 80,
+                           FailedBoard = 1,
+                           FlippedBoard = 1,
+                           ProductTypeId = "Product_A",
+                           WorkOrderIdentifier = new WorkOrderIdentifier()
+                           {
+                                WorkOrderId = "WO9988776666",
+                                Batch = "Batch1"
+                           }
+                       }
+                   }
+                }
             };
             AppendMessage(msg, ref result);
 


### PR DESCRIPTION
The CFX & Hermes Team discussed several combined CFX-Hermes use cases such as:
• loading PCBs at the begin of the SMT line, i.e. loading a magazine and requesting the necessary work order
• unloading PCBs at the end of the SMT line, i.e. putting PCBs into a magazine and moving it on to further production/assembly