### PR TITLE
Adding "Skipped" status for test result and validation result to support bad marks

### DIFF
--- a/CFX/Structures/ProcessingResult.cs
+++ b/CFX/Structures/ProcessingResult.cs
@@ -29,6 +29,10 @@ namespace CFX.Structures
         /// <summary>
         /// The processing was aborted by the operator / user.
         /// </summary>
-        Aborted
+        Aborted,
+        /// <summary>
+        /// The test was skipped because of (virtual) bad mark
+        /// </summary>
+        Skipped
     }
 }

--- a/CFX/Structures/TestResult.cs
+++ b/CFX/Structures/TestResult.cs
@@ -29,6 +29,10 @@ namespace CFX.Structures
         /// <summary>
         /// The test was aborted by the operator / user.
         /// </summary>
-        Aborted
+        Aborted,
+        /// <summary>
+        /// The test was skipped because of (virtual) bad mark
+        /// </summary>
+        Skipped
     }
 }

--- a/CFX/Structures/ValidationStatus.cs
+++ b/CFX/Structures/ValidationStatus.cs
@@ -19,6 +19,10 @@ namespace CFX.Structures
         /// <summary>
         /// The validation has failed (not succeeded)
         /// </summary>
-        Failed
+        Failed,
+        /// <summary>
+        /// The validation has skipped because of (virtual) bad mark
+        /// </summary>
+        Skipped
     }
 }

--- a/CFX/Structures/WorkResult.cs
+++ b/CFX/Structures/WorkResult.cs
@@ -25,6 +25,10 @@ namespace CFX.Structures
         /// <summary>
         /// Work was not completed
         /// </summary>
-        Aborted
+        Aborted,
+        /// <summary>
+        /// The test was skipped because of (virtual) bad mark
+        /// </summary>
+        Skipped
     }
 }


### PR DESCRIPTION
To support X-Out/Bad marks/Virtual Inkspots we added the "Skipped" status in ValidationResult and TestResult.
So that MES can tell the machine to skip defined modules via ValidateUnitsResponse and the machine also can set the related test result in UnitsInspected/UnitsTested.

![image](https://user-images.githubusercontent.com/83952135/117645083-74e99380-b18a-11eb-8a4e-e0b90567a481.png)


Example panel with 3 units -> 2 ok, 1 bad mark
![image](https://user-images.githubusercontent.com/83952135/118329363-309e2080-b507-11eb-9f3c-b3e626d60b19.png)

