### PR TITLE
Add test submission validation response

### DIFF
--- a/CFX/Production/TestAndInspection/UnitsInspectedRequest.cs
+++ b/CFX/Production/TestAndInspection/UnitsInspectedRequest.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.TestAndInspection
+{
+    /// <summary>
+    /// Alias of UnitsInspected for requests. See <see cref="UnitsInspected"/>
+    /// </summary>
+
+    public class UnitsInspectedRequest : UnitsInspected
+    {
+    }
+}

--- a/CFX/Production/TestAndInspection/UnitsInspectedResponse.cs
+++ b/CFX/Production/TestAndInspection/UnitsInspectedResponse.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.TestAndInspection
+{
+    /// <summary>
+    /// Sent from a process endpoint in order to validate the submission of the test result of an unit.  
+    /// Process endpoints, where configured, should send this request before allowing the unit to leave
+    /// the current process.
+    /// <code language="none">
+    /// {
+    ///   "Result": {
+    ///     "Result": "Success",
+    ///     "ResultCode": 0,
+    ///     "Message": null
+    ///   },
+    ///   "PrimaryResult": {
+    ///     "UniqueIdentifier": "CARRIER5566",
+    ///     "PositionNumber": 0,
+    ///     "Result": "Passed",
+    ///     "FailureCode": 0,
+    ///     "Message": "OK"
+    ///   },
+    ///   "TestValidationResults": [
+    ///     {
+    ///       "UniqueIdentifier": "CARRIER5566",
+    ///       "PositionNumber": 1,
+    ///       "Result": "Passed",
+    ///       "FailureCode": 0,
+    ///       "Message": "OK"
+    ///     },
+    ///     {
+    ///       "UniqueIdentifier": "CARRIER5566",
+    ///       "PositionNumber": 2,
+    ///       "Result": "Passed",
+    ///       "FailureCode": 0,
+    ///       "Message": "OK"
+    ///     }
+    ///   ]
+    /// }
+    /// </code>
+    /// </summary>
+    public class UnitsInspectedResponse : CFXMessage
+    {
+        public UnitsInspectedResponse()
+        {
+            Result = new RequestResult();
+            PrimaryResult = new TestValidationResult();
+            TestValidationResults = new List<TestValidationResult>();
+        }
+
+        /// <summary>
+        /// Result of the request
+        /// </summary>
+        public RequestResult Result
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Overall result of the test validation request
+        /// </summary>
+        public TestValidationResult PrimaryResult
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Individual results of the test validation request (for multiple units in a carrier or PCB Panel)
+        /// </summary>
+        public List<TestValidationResult> TestValidationResults
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Production/TestAndInspection/UnitsInspectedResponse.cs
+++ b/CFX/Production/TestAndInspection/UnitsInspectedResponse.cs
@@ -44,6 +44,9 @@ namespace CFX.Production.TestAndInspection
     /// </summary>
     public class UnitsInspectedResponse : CFXMessage
     {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
         public UnitsInspectedResponse()
         {
             Result = new RequestResult();

--- a/CFX/Production/TestAndInspection/UnitsTestedRequest.cs
+++ b/CFX/Production/TestAndInspection/UnitsTestedRequest.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.TestAndInspection
+{
+    /// <summary>
+    /// Alias of UnitsTested for requests. See <see cref="UnitsTested"/>
+    /// </summary>
+    public class UnitsTestedRequest : UnitsTested
+    {
+    }
+}

--- a/CFX/Production/TestAndInspection/UnitsTestedResponse.cs
+++ b/CFX/Production/TestAndInspection/UnitsTestedResponse.cs
@@ -44,6 +44,9 @@ namespace CFX.Production.TestAndInspection
     /// </summary>
     public class UnitsTestedResponse : CFXMessage
     {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
         public UnitsTestedResponse()
         {
             Result = new RequestResult();

--- a/CFX/Production/TestAndInspection/UnitsTestedResponse.cs
+++ b/CFX/Production/TestAndInspection/UnitsTestedResponse.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.Production.TestAndInspection
+{
+    /// <summary>
+    /// Sent from a process endpoint in order to validate the submission of the test result of an unit.  
+    /// Process endpoints, where configured, should send this request before allowing the unit to leave
+    /// the current process.
+    /// <code language="none">
+    /// {
+    ///   "Result": {
+    ///     "Result": "Success",
+    ///     "ResultCode": 0,
+    ///     "Message": null
+    ///   },
+    ///   "PrimaryResult": {
+    ///     "UniqueIdentifier": "CARRIER5566",
+    ///     "PositionNumber": 0,
+    ///     "Result": "Passed",
+    ///     "FailureCode": 0,
+    ///     "Message": "OK"
+    ///   },
+    ///   "TestValidationResults": [
+    ///     {
+    ///       "UniqueIdentifier": "CARRIER5566",
+    ///       "PositionNumber": 1,
+    ///       "Result": "Passed",
+    ///       "FailureCode": 0,
+    ///       "Message": "OK"
+    ///     },
+    ///     {
+    ///       "UniqueIdentifier": "CARRIER5566",
+    ///       "PositionNumber": 2,
+    ///       "Result": "Passed",
+    ///       "FailureCode": 0,
+    ///       "Message": "OK"
+    ///     }
+    ///   ]
+    /// }
+    /// </code>
+    /// </summary>
+    public class UnitsTestedResponse : CFXMessage
+    {
+        public UnitsTestedResponse()
+        {
+            Result = new RequestResult();
+            PrimaryResult = new TestValidationResult();
+            TestValidationResults = new List<TestValidationResult>();
+        }
+
+        /// <summary>
+        /// Result of the request
+        /// </summary>
+        public RequestResult Result
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Overall result of the test validation request
+        /// </summary>
+        public TestValidationResult PrimaryResult
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Individual results of the test validation request (for multiple units in a carrier or PCB Panel)
+        /// </summary>
+        public List<TestValidationResult> TestValidationResults
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/TestValidationResult.cs
+++ b/CFX/Structures/TestValidationResult.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CFX.Structures
+{
+    public class TestValidationResult
+    {
+        public TestValidationResult()
+        {
+        }
+
+        public string UniqueIdentifier
+        {
+            get;
+            set;
+        }
+
+        public int PositionNumber
+        {
+            get;
+            set;
+        }
+
+        public TestValidationStatus Result
+        {
+            get;
+            set;
+        }
+
+        public int FailureCode
+        {
+            get;
+            set;
+        }
+
+        public string Message
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/TestValidationStatus.cs
+++ b/CFX/Structures/TestValidationStatus.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CFX.Structures
+{
+    /// <summary>
+    /// The result of a test validation operation
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum TestValidationStatus
+    {
+        /// <summary>
+        /// The test validation has succeeded
+        /// </summary>
+        Passed,
+        /// <summary>
+        /// The test validation has failed (not succeeded)
+        /// </summary>
+        Failed,
+        /// <summary>
+        /// The test validation has skipped because of (virtual) bad mark
+        /// </summary>
+        Skipped
+    }
+}


### PR DESCRIPTION
Currently UnitsInspected and UnitsTested are designed as events only (fire and forget). But it is very common (and mandatory in our field) that the process should be only continued if the test result submission is acknowledged by the MES system. Especially when traceability is a must have like for example in automotive or medical area.

This pull request introduces responses for UnitsInspected and UnitsTested -> UnitsInspectedResponse & UnitsTestedResponse (like ValidateUnitsResponse). So it can be decided if the test/inspection result is sent as event or direct request.

