### PR TITLE
Add optional TotalInspectionCount to InspectedUnit message.

### DIFF
--- a/CFX/Structures/InspectedUnit.cs
+++ b/CFX/Structures/InspectedUnit.cs
@@ -63,5 +63,20 @@ namespace CFX.Structures
             set;
         }
 
+        /// <summary>
+        /// The count of all the inspections performed.  
+        /// If The Inspections array includes both passed and failed inspections
+        /// then this parameter would just be the length of that array.  
+        /// However if only failed inspections are included in the Inspections
+        /// array then just the number of inspections performed (passing and failing) 
+        /// can be communicated here so that receiving system can calculate defect
+        /// rates. 
+        /// </summary>
+        public int? TotalInspectionCount
+        {
+            get;
+            set;
+        }
+
     }
 }


### PR DESCRIPTION
Per discussion in the CFX A-Team.  This adds an optional `TotalInspectionCount` property to `InspectedUnit` in case inspection machines only include failing inspections in the `Inspections` array, which is common practice to limit message sizes.

This optional int property allows inspection machines to communicate the number of total tests performed if they
choose to only including failing inspections in the Inspections array itself to facilitate the computation of quantities like defects per million opportunities that need to know the number of total inspections (pass or fail).