### PR TITLE
Asmpt expected work time 1.6

### DIFF
--- a/CFX/CFXnet46.csproj
+++ b/CFX/CFXnet46.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <PackageId>CFX.CFXSDK</PackageId>
     <PackageVersion>1.5.3</PackageVersion>
     <Authors>IPC CFX Committee</Authors>

--- a/CFX/Production/RecipeActivated.cs
+++ b/CFX/Production/RecipeActivated.cs
@@ -104,11 +104,22 @@ namespace CFX.Production
         }
 
         /// <summary>
-        /// The number of units that are to be processed simulataneously by this recipe.  For example, in the case of a 2 x 2 panelized PCB, this
-        /// property would be 4 because 4 units (PCBs) are procesed at one time per work transaction.  In the case that a station processes a
-        /// variable number of units per transaction, this should represent the average number of units expected to be processed per transaction.
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// The total amount of productive time (in ms) that is expected to process one unit or group of units (as in the case of a carrier or panelized PCB),
+        /// assuming no blocked or starved conditions at the station. This does not include any non-productive time, such as transfer, positioning, etc.
         /// </summary>
-        public double ExpectedUnitsPerWorkTransaction
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public double? ExpectedWorkTime
+        {
+            get;
+            set;
+        }
+    /// <summary>
+    /// The number of units that are to be processed simulataneously by this recipe.  For example, in the case of a 2 x 2 panelized PCB, this
+    /// property would be 4 because 4 units (PCBs) are procesed at one time per work transaction.  In the case that a station processes a
+    /// variable number of units per transaction, this should represent the average number of units expected to be processed per transaction.
+    /// </summary>
+    public double ExpectedUnitsPerWorkTransaction
         {
             get;
             set;

--- a/CFX/Production/WorkCompleted.cs
+++ b/CFX/Production/WorkCompleted.cs
@@ -15,9 +15,17 @@ namespace CFX.Production
     /// <code language="none">
     /// {
     ///   "TransactionID": "2c24590d-39c5-4039-96a5-91900cecedfa",
-    ///   "Result": "Completed"
+    ///   "Result": "Completed",
+    ///   "PrimaryIdentifier": null,
+    ///   "HermesIdentifier": null,
+    ///   "UnitCount": 0,
+    ///   "Units": [],
+    ///   "PerformanceImpacts": [
+    ///     {
+    ///       "Cause": "AdditionalImageAcquisition"
+    ///     }
+    ///   ]
     /// }
-    /// </code>
     /// </summary>
     public class WorkCompleted : CFXMessage 
     {
@@ -103,6 +111,18 @@ namespace CFX.Production
         /// Data that identifies each specific instance of production unit with a carrier or panel. 
         /// </summary>
         public List<UnitPosition> Units
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// The total amount of productive time (in ms) that is expected to process one unit or group of units (as in the case of a carrier or panelized PCB),
+        /// assuming no blocked or starved conditions at the station. This does not include any non-productive time, such as transfer, positioning, etc.
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public List<PerformanceImpact> PerformanceImpacts
         {
             get;
             set;

--- a/CFX/Production/WorkCompleted.cs
+++ b/CFX/Production/WorkCompleted.cs
@@ -12,6 +12,8 @@ namespace CFX.Production
 {
     /// <summary>
     /// Sent by a process endpoint when all work has been completed at a process endpoint.
+    /// <para>Generic example</para>
+    /// <para>  </para>
     /// <code language="none">
     /// {
     ///   "TransactionID": "2c24590d-39c5-4039-96a5-91900cecedfa",
@@ -19,13 +21,43 @@ namespace CFX.Production
     ///   "PrimaryIdentifier": null,
     ///   "HermesIdentifier": null,
     ///   "UnitCount": 0,
-    ///   "Units": [],
+    ///   "Units": []
+    /// }
+    /// <para>Example with PerformanceImpact empty - no performance impact</para>
+    /// <para>  </para>
+    /// <code language="none">
+    /// {
+    ///   "TransactionID": "2c24590d-39c5-4039-96a5-91900cecedfa",
+    ///   "Stage": {
+    ///     "StageSequence": 1,
+    ///     "StageName": "STAGE1",
+    ///     "StageType": "Work"
+    ///   },
+    ///   "Result": "Completed",
+    ///   "PerformanceImpacts": []
+    /// }
+    /// </code>
+    /// <para>Example with PerformanceImpact</para>
+    /// <para>  </para>
+    /// <code language="none">
+    /// {
+    ///   "TransactionID": "2c24590d-39c5-4039-96a5-91900cecedfa",
+    ///   "Stage": {
+    ///     "StageSequence": 1,
+    ///     "StageName": "STAGE1",
+    ///     "StageType": "Work"
+    ///   },
+    ///   "Result": "Completed",
     ///   "PerformanceImpacts": [
     ///     {
-    ///       "Cause": "AdditionalImageAcquisition"
+    ///       "Cause": "LowFeederSpeed"
+    ///     },
+    ///     {
+    ///       "Cause": "AlternativeTrackUsed"
     ///     }
     ///   ]
     /// }
+    /// </code>
     /// </summary>
     public class WorkCompleted : CFXMessage 
     {

--- a/CFX/Production/WorkStageCompleted.cs
+++ b/CFX/Production/WorkStageCompleted.cs
@@ -20,7 +20,8 @@ namespace CFX.Production
     ///     "StageName": "STAGE1",
     ///     "StageType": "Work"
     ///   },
-    ///   "Result": "Completed"
+    ///   "Result": "Completed",
+    ///   "PerformanceImpacts": null
     /// }
     /// </code>
     /// </summary>
@@ -48,6 +49,18 @@ namespace CFX.Production
         /// An enumeration indicating the overall result of the Work transaction
         /// </summary>
         public WorkResult Result
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// The total amount of productive time (in ms) that is expected to process one unit or group of units (as in the case of a carrier or panelized PCB),
+        /// assuming no blocked or starved conditions at the station. This does not include any non-productive time, such as transfer, positioning, etc.
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public List<PerformanceImpact> PerformanceImpacts
         {
             get;
             set;

--- a/CFX/Production/WorkStageCompleted.cs
+++ b/CFX/Production/WorkStageCompleted.cs
@@ -21,7 +21,14 @@ namespace CFX.Production
     ///     "StageType": "Work"
     ///   },
     ///   "Result": "Completed",
-    ///   "PerformanceImpacts": null
+    ///   "PerformanceImpacts": [
+    ///     {
+    ///       "Cause": "LowFeederSpeed"
+    ///     },
+    ///     {
+    ///       "Cause": "AlternativeTrackUsed"
+    ///     }
+    ///   ]
     /// }
     /// </code>
     /// </summary>

--- a/CFX/Structures/PerformanceImpact.cs
+++ b/CFX/Structures/PerformanceImpact.cs
@@ -10,6 +10,7 @@ namespace CFX.Structures
     /// It shall be "null" or not sent at all if the machine doesn't support the PerformanceImpact attribute.
     /// An empty list indicates that the machine is running at "best-performance"
     /// </summary>
+    [CFX.Utilities.CreatedVersion("1.6")]
     public class PerformanceImpact
     {
         /// <summary>

--- a/CFX/Structures/PerformanceImpact.cs
+++ b/CFX/Structures/PerformanceImpact.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CFX.Structures
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+    /// Performance impacts of a machine (i.e., in case of lower-than-expected performance) 
+    /// </summary>
+    public class PerformanceImpact
+    {
+        /// <summary>
+        /// The cause of this performance impact.
+        /// </summary>
+        public PerformanceImpactCause Cause
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/PerformanceImpact.cs
+++ b/CFX/Structures/PerformanceImpact.cs
@@ -6,10 +6,19 @@ namespace CFX.Structures
 {
     /// <summary>
     /// <para>** NOTE: ADDED in CFX 1.6 **</para>
-    /// Performance impacts of a machine (i.e., in case of lower-than-expected performance) 
+    /// Performance impacts of a machine (i.e., in case of lower-than-expected performance)
+    /// It shall be "null" or not sent at all if the machine doesn't support the PerformanceImpact attribute.
+    /// An empty list indicates that the machine is running at "best-performance"
     /// </summary>
     public class PerformanceImpact
     {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public PerformanceImpact()
+        {
+            
+        }
         /// <summary>
         /// The cause of this performance impact.
         /// </summary>

--- a/CFX/Structures/PerformanceImpactCause.cs
+++ b/CFX/Structures/PerformanceImpactCause.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CFX.Structures
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+    /// Possible causes of lower-than-expected performance, which a machine may be able to report as performance impacts
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("1.6")]
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum PerformanceImpactCause
+    {
+        /// <summary>
+        /// An alternative track was used for component pick-up
+        /// </summary>
+        AlternativeTrackUsed,
+        /// <summary>
+        /// A segment on a head was deactivated
+        /// </summary>
+        DeactivatedSegmentOnHead,
+        /// <summary>
+        /// Option “Dump Always” activated for vision system
+        /// </summary>
+        VisionSystemDumpAlwaysActivated,
+        /// <summary>
+        /// Vision system had to acquire additional images
+        /// </summary>
+        AdditionalImageAcquisition,
+        /// <summary>
+        /// Feeder speed is lower than expected
+        /// </summary>
+        LowFeederSpeed,
+        /// <summary>
+        /// Gang pick head cannot pick in parallel
+        /// </summary>
+        GangPickNoParallelPick
+    }
+}

--- a/CFX/Structures/Recipe.cs
+++ b/CFX/Structures/Recipe.cs
@@ -48,6 +48,17 @@ namespace CFX.Structures
             get;
             set;
         }
+        /// <summary>
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// The total amount of productive time (in ms) that is expected to process one unit or group of units (as in the case of a carrier or panelized PCB),
+        /// assuming no blocked or starved conditions at the station. This does not include any non-productive time, such as transfer, positioning, etc.
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public double? ExpectedWorkTime
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// The number of units that are to be processed simulataneously by this recipe.  For example, in the case of a 2 x 2 panelized PCB, this

--- a/CFX/Structures/RecipeStageInformation.cs
+++ b/CFX/Structures/RecipeStageInformation.cs
@@ -32,7 +32,17 @@ namespace CFX.Structures
             get;
             set;
         }
-
+        /// <summary>
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// The total amount of productive time (in ms) that is expected to process one unit or group of units (as in the case of a carrier or panelized PCB),
+        /// assuming no blocked or starved conditions at the station. This does not include any non-productive time, such as transfer, positioning, etc.
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public double? ExpectedWorkTime
+        {
+            get;
+            set;
+        }
         /// <summary>
         /// The number of components to install for each unit of a work for a stage of the machine.
         /// </summary>

--- a/CFXExampleEndpoint/App.config
+++ b/CFXExampleEndpoint/App.config
@@ -6,7 +6,7 @@
     </sectionGroup>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
   <userSettings>
     <CFXExampleEndpoint.Properties.Settings>

--- a/CFXExampleEndpoint/CFXExampleEndpoint.csproj
+++ b/CFXExampleEndpoint/CFXExampleEndpoint.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>CFXExampleEndpoint</RootNamespace>
     <AssemblyName>CFXExampleEndpoint</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/CFXExampleEndpoint/CFXExampleGenerator.cs
+++ b/CFXExampleEndpoint/CFXExampleGenerator.cs
@@ -3065,7 +3065,14 @@ namespace CFXExampleEndpoint
             msg = new WorkCompleted()
             {
                 TransactionID = transId,
-                Result = WorkResult.Completed
+                Result = WorkResult.Completed,
+                PerformanceImpacts = new List<PerformanceImpact>()
+                {
+                    new PerformanceImpact()
+                    {
+                        Cause = PerformanceImpactCause.AdditionalImageAcquisition,
+                    }
+                }
             };
             AppendMessage(msg, ref result);
 
@@ -3078,6 +3085,25 @@ namespace CFXExampleEndpoint
                     StageName = "STAGE1",
                     StageType = StageType.Work
                 },
+                PerformanceImpacts = new List<PerformanceImpact>()
+                {
+                    new PerformanceImpact()
+                    {
+                        Cause = PerformanceImpactCause.LowFeederSpeed,
+                    }
+                }
+            };
+            AppendMessage(msg, ref result);
+
+            msg = new WorkStageCompleted()
+            {
+                TransactionID = transId,
+                Stage = new Stage()
+                {
+                    StageSequence = 1,
+                    StageName = "STAGE1",
+                    StageType = StageType.Work
+                }
             };
             AppendMessage(msg, ref result);
 

--- a/CFXExampleEndpoint/CFXExampleGenerator.cs
+++ b/CFXExampleEndpoint/CFXExampleGenerator.cs
@@ -3076,6 +3076,25 @@ namespace CFXExampleEndpoint
             };
             AppendMessage(msg, ref result);
 
+            msg = new WorkCompleted()
+            {
+                TransactionID = transId,
+                Result = WorkResult.Completed,
+                PerformanceImpacts = new List<PerformanceImpact>()
+                {
+                   
+                }
+            };
+            AppendMessage(msg, ref result);
+
+            msg = new WorkCompleted()
+            {
+                TransactionID = transId,
+                Result = WorkResult.Completed,
+              
+            };
+            AppendMessage(msg, ref result);
+
             msg = new WorkStageCompleted()
             {
                 TransactionID = transId,
@@ -3089,7 +3108,11 @@ namespace CFXExampleEndpoint
                 {
                     new PerformanceImpact()
                     {
-                        Cause = PerformanceImpactCause.LowFeederSpeed,
+                        Cause = PerformanceImpactCause.LowFeederSpeed
+                    },
+                    new PerformanceImpact()
+                    {
+                        Cause = PerformanceImpactCause.AlternativeTrackUsed
                     }
                 }
             };

--- a/CFXExampleEndpoint/MainForm.Designer.cs
+++ b/CFXExampleEndpoint/MainForm.Designer.cs
@@ -65,7 +65,7 @@
             this.label1.Location = new System.Drawing.Point(16, 34);
             this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(121, 17);
+            this.label1.Size = new System.Drawing.Size(113, 16);
             this.label1.TabIndex = 1;
             this.label1.Text = "Publish Channels:";
             // 
@@ -116,7 +116,7 @@
             this.label2.Location = new System.Drawing.Point(15, 31);
             this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(83, 17);
+            this.label2.Size = new System.Drawing.Size(79, 16);
             this.label2.TabIndex = 5;
             this.label2.Text = "CFX Handle";
             // 
@@ -169,7 +169,7 @@
             this.label3.Location = new System.Drawing.Point(364, 31);
             this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(83, 17);
+            this.label3.Size = new System.Drawing.Size(78, 16);
             this.label3.TabIndex = 11;
             this.label3.Text = "Request Uri";
             // 
@@ -211,7 +211,7 @@
             this.label4.Location = new System.Drawing.Point(740, 34);
             this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(138, 17);
+            this.label4.Size = new System.Drawing.Size(130, 16);
             this.label4.TabIndex = 13;
             this.label4.Text = "Subscribe Channels:";
             // 
@@ -249,7 +249,6 @@
             this.btnDeserializeOfflineJson.TabIndex = 19;
             this.btnDeserializeOfflineJson.Text = "Deserialize Json";
             this.btnDeserializeOfflineJson.UseVisualStyleBackColor = true;
-            this.btnDeserializeOfflineJson.Visible = false;
             this.btnDeserializeOfflineJson.Click += new System.EventHandler(this.btnDeserializeOfflineJson_Click);
             // 
             // reqHandle
@@ -266,7 +265,7 @@
             this.label6.Location = new System.Drawing.Point(740, 149);
             this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(103, 17);
+            this.label6.Size = new System.Drawing.Size(97, 16);
             this.label6.TabIndex = 17;
             this.label6.Text = "Target Handle:";
             // 
@@ -284,7 +283,7 @@
             this.label5.Location = new System.Drawing.Point(740, 117);
             this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(76, 17);
+            this.label5.Size = new System.Drawing.Size(70, 16);
             this.label5.TabIndex = 15;
             this.label5.Text = "Target Uri:";
             // 
@@ -344,7 +343,7 @@
             this.label7.Location = new System.Drawing.Point(665, 31);
             this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(203, 17);
+            this.label7.Size = new System.Drawing.Size(194, 16);
             this.label7.TabIndex = 13;
             this.label7.Text = "Request Username / Password";
             // 

--- a/CFXExampleEndpoint/Properties/Resources.Designer.cs
+++ b/CFXExampleEndpoint/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CFXExampleEndpoint.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/CFXExampleEndpoint/Properties/Settings.Designer.cs
+++ b/CFXExampleEndpoint/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CFXExampleEndpoint.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/CFXUnitTests/CFXUnitTests.csproj
+++ b/CFXUnitTests/CFXUnitTests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CFXUnitTests</RootNamespace>
     <AssemblyName>CFXUnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/CFXUnitTests/Properties/Settings.Designer.cs
+++ b/CFXUnitTests/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CFXUnitTests.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/CFXUnitTests/app.config
+++ b/CFXUnitTests/app.config
@@ -48,4 +48,4 @@
             </setting>
         </CFXUnitTests.Properties.Settings>
     </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
Introduced ExpectedWorkTime attribute and the PerformanceImpact (PerformanceImpactCause) to manage the performance impact info (e.g., when a machine cannot run at the "best" performance.
NOTE: to compile in VS2022 I had to temporary use .Net Framework 4.8 - ignore it if not relevant for the "master"