### PR TITLE
Additions of additional properties (optional) to the WorkOrderActionExecuted message

### DIFF
--- a/CFX/Production/WorkOrderActionExecuted.cs
+++ b/CFX/Production/WorkOrderActionExecuted.cs
@@ -89,5 +89,40 @@ namespace CFX.Production
             get;
             set;
         }
+
+        /// <summary>
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// For two-dimensional products, such as printed circuit assemblies,
+        /// specifies the relevant surface that is concerned by the action. (optional)
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public Surface RelevantSurface
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// The name of the recipe, when a particular surface and a particular machine
+        /// are involved in the action (may include full path, if applicable) (optional)
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public string RecipeName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// <para>** NOTE: ADDED in CFX 1.6 **</para>
+        /// Recipe version number, when a recipe name is defined (optional)
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("1.6")]
+        public string RecipeRevision
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
CFX.Production.WorkOrderActionExecuted is a message intended to be sent when a non-added value action (out of production) relative to a work order is started, aborted or completed by a process endpoint. The main properties are of course the work order identifier, but also an enum that describes the action, like recipe modification, material setup, material replenishment, etc.

In many cases it should be very interesting to also have the surface concerned by the action, and also the recipe, when a specific machine is involved (which is the case for all the already defined possible actions, I think).

Nevertheless, I think that the surface and the recipe should be optional, because sometimes an action just concerns the work-order in general, not a specific surface. Or sometimes it can concern a specific surface but not a specific machine, so not a specific recipe.

(Validated by the A-Team)