### PR TITLE
Fixing the SMTLogEntryAdditionalData class (it was private instead of public)

### DIFF
--- a/CFX/Structures/SMTPlacement/SMTLogEntryAdditionalData.cs
+++ b/CFX/Structures/SMTPlacement/SMTLogEntryAdditionalData.cs
@@ -5,7 +5,7 @@
     /// A specialized type of LogEntryRecordedData for an SMT machine
     /// </summary>
     [CFX.Utilities.CreatedVersion("1.4")]
-    class SMTLogEntryAdditionalData : LogEntryAdditionalData
+    public class SMTLogEntryAdditionalData : LogEntryAdditionalData
     {
         /// <summary>
         /// The particular Head/Nozzle related to the log entry (where applicable)


### PR DESCRIPTION
Without this fix, it is impossible to use this class.
Should be included in 1.6, but maybe also in 1.5.