### PR TITLE
CFX version update in envelope

### DIFF
--- a/CFX/CFXEnvelope.cs
+++ b/CFX/CFXEnvelope.cs
@@ -45,7 +45,7 @@ namespace CFX
             Transmitted = false;
         }
 
-        public const string CFXVERSION = "1.4";
+        public const string CFXVERSION = "1.6";
         
         public CFXEnvelope(Type messageType) : this()
         {

--- a/CFX/Structures/SMTPlacement/SMTLogEntryAdditionalData.cs
+++ b/CFX/Structures/SMTPlacement/SMTLogEntryAdditionalData.cs
@@ -5,7 +5,7 @@
     /// A specialized type of LogEntryRecordedData for an SMT machine
     /// </summary>
     [CFX.Utilities.CreatedVersion("1.4")]
-    class SMTLogEntryAdditionalData : LogEntryAdditionalData
+    public class SMTLogEntryAdditionalData : LogEntryAdditionalData
     {
         /// <summary>
         /// The particular Head/Nozzle related to the log entry (where applicable)


### PR DESCRIPTION
The CFX version that is set in the message's envelope was still 1.4.
This should be also fixed for 1.5 I think.