### PR TITLE
UnblockMaterialsResponse.Result property should be public.

### DIFF
--- a/CFX/Materials/Management/UnblockMaterialsResponse.cs
+++ b/CFX/Materials/Management/UnblockMaterialsResponse.cs
@@ -30,7 +30,7 @@ namespace CFX.Materials.Management
         /// <summary>
         /// The result of the request
         /// </summary>
-        RequestResult Result
+        public RequestResult Result
         {
             get;
             set;


### PR DESCRIPTION
The Result property of UnblockMaterialsResponse is currently private and can't be accessed. 