### PR TITLE
Feat heartbeats and operators

### DIFF
--- a/CFX/Heartbeat.cs
+++ b/CFX/Heartbeat.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using CFX.Structures;
 
 namespace CFX
 {
@@ -33,6 +34,33 @@ namespace CFX
         /// The amount of time to expect between Heartbeast messasges for this endpoint
         /// </summary>
         public TimeSpan HeartbeatFrequency
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Any faults currently active on this endpoint.  Faults should be repeated here until cleared. 
+        /// Leaving this parameter as null means that active faults are not known.  Setting it to an
+        /// empty List implies positive knowledge that there are no active faults.
+        /// </summary>
+        public List<Fault> ActiveFaults
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Any recipes currently active on this endpoint.  Recipes may be specified either using
+        /// their identifiers or by including recipe details such as expected cycle times depending
+        /// on what information the endpoing is able to communicate.
+        ///
+        /// Leaving this parameter as null means that active recipes are not known.  Setting it to an
+        /// empty List implies positive knowledge that there are no active recipes.
+        ///
+        /// Multiple recipes may be active at once on a given endpoint.
+        /// </summary>
+        public List<ActiveRecipe> ActiveRecipes
         {
             get;
             set;

--- a/CFX/InformationSystem/ValidateOperatorRequest.cs
+++ b/CFX/InformationSystem/ValidateOperatorRequest.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.InformationSystem
+{
+    /// <summary>
+    /// Request that an operator take action now or be responsible for a process endpoint.
+    /// The opposite endpoint can accept or reject this. Can be used if the MES has 
+    /// advanced user management. Multiple operators must be requested separately. 
+    /// <code language="none">
+    /// {
+    ///   "Operator": {
+    ///     "OperatorIdentifier": "42b7a5cc-3bbd-4010-8a01-1c5851b9a2a3",
+    ///     "ActorType": "Human",
+    ///     "LastName": "Smith",
+    ///     "FirstName": "Bill",
+    ///     "LoginName": "bill.smith@domain1.com"
+    ///   }
+    /// }
+    /// </code>
+    /// </summary>
+    public class ValidateOperatorRequest : CFXMessage
+    {
+        /// <summary>
+        /// A structure which defines the Operator.
+        /// </summary>
+        public Operator Operator
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/InformationSystem/ValidateOperatorResponse.cs
+++ b/CFX/InformationSystem/ValidateOperatorResponse.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures;
+
+namespace CFX.InformationSystem
+{
+    /// <summary>
+    /// Response to a request that the operator's login was successful or not.
+    /// <code language="none">
+    /// {
+    ///   "Result": {
+    ///     "Result": "Success",
+    ///     "ResultCode": 0,
+    ///     "Message": "OK"
+    ///   }
+    /// }
+    /// </code>
+    /// </summary>
+    public class ValidateOperatorResponse : CFXMessage
+    {
+        /// <summary>
+        /// The result of the request
+        /// </summary>
+        public RequestResult Result
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/ActiveRecipe.cs
+++ b/CFX/Structures/ActiveRecipe.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace CFX.Structures
+{
+    /// <summary>
+    /// <para> ** NOTE: ADDED in CFX 1.7 **</para>
+    /// Represents a recipe active on a certain lane inside of a machine.
+    /// This is equivalent to the information present in a <see cref="CFX.Production.RecipeActivated"/> message
+    /// but represented as a structure so that it can be included in the <see cref="CFX.Heartbeat"/>
+    /// message.
+    /// </summary>
+
+    [CFX.Utilities.CreatedVersion("1.7")]
+    public class ActiveRecipe
+    {
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public ActiveRecipe()
+        {
+        }
+
+        /// <summary>
+        /// Number of the production lane (if applicable)
+        /// </summary>
+        public int? Lane
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// An optional stage
+        /// </summary>
+        public Stage Stage
+        {
+            get;
+            set;
+        } 
+
+        /// <summary>
+        /// The identifier of the active recipe.
+        /// If the complete recipe is known, Recipe should be used instead.
+        /// </summary>
+        public RecipeIdentifier RecipeIdentifier;
+
+        /// <summary>
+        /// The details of the active recipe.
+        /// If the recipe details are not known then RecipeIdentifier should
+        /// be used instead.
+        /// </summary>
+        public Recipe Recipe;
+    }
+}


### PR DESCRIPTION
This PR does two different things to merge both for the 1.7 CFX release:

1. Edits PR #169 to adjust the namespace per A-team recommendation.  All contents of PR 169 are otherwise unchanged.
2. Adds two fields to Heartbeat messages to be able to report active faults and recipes for any endpoint.

Note that for `ActiveRecipes`, there was not an existing structure that combined both a Recipe or RecipeIdentifier and a location on an endpoint.  That information was directly put together inside of the RecipeActivated message itself, so I created an ActiveRecipe structure to allow for reusing this.

For `ActiveFaults`, there was not additional information in `FaultActivated` to tie the fault to a location other than what was inside the `Fault` structure itself so there was no need for creating a new structure to include inside of the Heartbeat message.