### PR TITLE
Updated PCBSelectiveSoldered documentation to mention UnitsProcessed should be preferred 

### DIFF
--- a/CFX/Production/Application/Solder/PCBSelectiveSoldered.cs
+++ b/CFX/Production/Application/Solder/PCBSelectiveSoldered.cs
@@ -166,6 +166,12 @@ namespace CFX.Production.Application.Solder
     ///   ]
     /// }
     /// </code>
+    /// <remarks>
+    /// This was an early message; the standard has since moved to the
+    /// <see cref="UnitsProcessed"/> with 
+    /// <see cref="SelectiveSolderPCBProcessData"/> as the data being sent. You
+    /// should prefer using these over the <c>PCBSelectiveSoldered</v>.
+    /// </remaks>
     /// </summary>
     public class PCBSelectiveSoldered : CFXMessage
     {

--- a/CFX/Production/Application/Solder/PCBSelectiveSoldered.cs
+++ b/CFX/Production/Application/Solder/PCBSelectiveSoldered.cs
@@ -170,7 +170,7 @@ namespace CFX.Production.Application.Solder
     /// This was an early message; the standard has since moved to the
     /// <see cref="UnitsProcessed"/> with 
     /// <see cref="SelectiveSolderPCBProcessData"/> as the data being sent. You
-    /// should prefer using these over the <c>PCBSelectiveSoldered</v>.
+    /// should prefer using these over the <c>PCBSelectiveSoldered</c>.
     /// </remaks>
     /// </summary>
     public class PCBSelectiveSoldered : CFXMessage


### PR DESCRIPTION
Resolves #205 

As discussed in #31 it appears the `PCBSelectiveSoldered` message is not the preferred way sending this data and that the `UnitsProcessed` message should be used instead. This PR adds a remarks section to the `PCBSelectiveSoldered` documentation that discusses this.