### PR TITLE
Bugfix corrupted cache

### DIFF
--- a/CFX/CFXEnvelope.cs
+++ b/CFX/CFXEnvelope.cs
@@ -36,6 +36,8 @@ namespace CFX
     [JsonObject(MemberSerialization.OptIn, ItemTypeNameHandling = TypeNameHandling.Auto)]
     public class CFXEnvelope
     {
+        private const int maxLength = 32_000_000;//maximum message size ~32MB
+
         public CFXEnvelope()
         {
             UniqueID = Guid.NewGuid();
@@ -239,6 +241,11 @@ namespace CFX
                 long filePosition = reader.BaseStream.Position;
                 bool transmitted = reader.ReadBoolean();
                 Int32 len = reader.ReadInt32();
+                if (len > maxLength)
+                {
+                    reader.BaseStream.Seek(0, SeekOrigin.End);
+                    throw new IOException("Input message is bigger than maximum allowed");
+                }
                 byte[] data = reader.ReadBytes(len);
                 CFXEnvelope result = FromBytes(data);
                 result.QueueFilePosition = filePosition;

--- a/CFX/CFXEnvelope.cs
+++ b/CFX/CFXEnvelope.cs
@@ -266,7 +266,7 @@ namespace CFX
             writer.Write(Transmitted);
             byte[] data = this.ToBytes();
             writer.Write((Int32)data.Length);
-            writer.Write(this.ToBytes());
+            writer.Write(data);
         }
 
         internal void SetRecordTransmitted(BinaryWriter writer)


### PR DESCRIPTION
I've noticed that at application start memory consumption jumped to 1.7GB
Reason is corrupted cache file in %LocalAppData%\Temp\
which lead to invalid number of bytes to be read from file in CFXEnvelope.ReadRecord
BinaryReader.ReadBytes(len) always create buffer byte array with requested len.

Proposal is to limit maximum allowed CFXMessage size to 32MB
In case message in BinaryReader is bigger - invalidate cache.
![Screenshot 2024-07-02 133313](https://github.com/IPCConnectedFactoryExchange/CFX/assets/67790659/f6881cf6-2f3e-43aa-8b8e-9e0df03d1768)
