### PR TITLE
Fix for clearing all channels related to a URI when unsubscribing from a subscribe or publish channel. issues/116

### DIFF
--- a/CFX/Transport/AmqpCFXEndpoint.cs
+++ b/CFX/Transport/AmqpCFXEndpoint.cs
@@ -658,7 +658,7 @@ namespace CFX.Transport
         public void ClosePublishChannel(Uri networkAddress, string address)
         {
             if (!IsOpen) throw new Exception("The Endpoint must be open before adding or removing channels.");
-            string key = networkAddress.ToString()
+            string key = networkAddress.ToString();
 
             AmqpConnection channel = null;
             if (channels.ContainsKey(key))

--- a/CFX/Transport/AmqpCFXEndpoint.cs
+++ b/CFX/Transport/AmqpCFXEndpoint.cs
@@ -658,12 +658,12 @@ namespace CFX.Transport
         public void ClosePublishChannel(Uri networkAddress, string address)
         {
             if (!IsOpen) throw new Exception("The Endpoint must be open before adding or removing channels.");
-            string key = networkAddress.ToString();
+            string key = networkAddress.ToString()
 
             AmqpConnection channel = null;
             if (channels.ContainsKey(key))
             {
-                while (!channels.TryRemove(key, out channel)) Task.Yield();
+                channel = channels[key];
                 channel.RemoveChannel(address);
             }
             else
@@ -740,7 +740,7 @@ namespace CFX.Transport
             AmqpConnection channel = null;
             if (channels.ContainsKey(key))
             {
-                while (!channels.TryRemove(key, out channel)) Task.Yield();
+                channel = channels[key];
                 channel.RemoveChannel(address);
             }
             else

--- a/CFX/Transport/AmqpCFXEndpoint.cs
+++ b/CFX/Transport/AmqpCFXEndpoint.cs
@@ -665,6 +665,10 @@ namespace CFX.Transport
             {
                 channel = channels[key];
                 channel.RemoveChannel(address);
+                if (channel.ChannelsEmpty())
+                {
+                    while (!channels.TryRemove(key, out channel)) Task.Yield();
+                }
             }
             else
             {
@@ -742,6 +746,10 @@ namespace CFX.Transport
             {
                 channel = channels[key];
                 channel.RemoveChannel(address);
+                if (channel.ChannelsEmpty())
+                {
+                    while (!channels.TryRemove(key, out channel)) Task.Yield();
+                }
             }
             else
             {

--- a/CFX/Transport/AmqpConnection.cs
+++ b/CFX/Transport/AmqpConnection.cs
@@ -357,6 +357,13 @@ namespace CFX.Transport
             channel.CloseLink();
         }
 
+        public bool ChannelsEmpty()
+        {
+            if (links == null) return true;
+
+            return links.Count == 0;
+        }
+        
         public void Close()
         {
             StopKeepAliveTimer();


### PR DESCRIPTION
Changed CloseSubscribeChannel and ClosePublishChannel to not remove the networkAddress channel key from the dictionary

// removed
while (!channels.TryRemove(key, out channel)) Task.Yield();

// replaced
channel = channels[key];

this allows one to add multiple subscription channels for one URI AND then remove them.

//re-added 
// only when 'List<>'channel.channels is empty
while (!channels.TryRemove(key, out channel)) Task.Yield();

issue existing since 2021 see:
https://github.com/IPCConnectedFactoryExchange/CFX/issues/116