### PR TITLE
Add data classes for a new endpoint type "dispensing machine"

### DIFF
--- a/CFX/Structures/CalibrationType.cs
+++ b/CFX/Structures/CalibrationType.cs
@@ -116,7 +116,10 @@ namespace CFX.Structures
         /// <para>** NOTE: ADDED in CFX 1.3 **</para>
         /// Vacuum tool
         /// </summary>
-        VacuumTooling
-
+        VacuumTooling,
+        /// <summary>
+        /// Dispensing valve
+        /// </summary>
+        DispensingValve
     }
 }

--- a/CFX/Structures/Dispensing/DispenserEndpoint.cs
+++ b/CFX/Structures/Dispensing/DispenserEndpoint.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CFX.Structures.Dispensing
+{
+    /// <summary>
+    /// Describes the details of a particular CFX endpoint involved in the application of material (dispensing),  
+    /// such glue dispensing and solder jetting.  This is a dynamic structure.
+    /// </summary>
+    public class DispenserEndpoint : Endpoint
+    {
+        /// <summary>
+        /// Default Constructor.
+        /// </summary>
+        public DispenserEndpoint()
+        {
+            Lanes = new List<DispenserLaneInformation>();
+            Heads = new List<DispenserHeadInformation>();
+        }
+
+        /// <summary>
+        /// Information about the production lanes of this dispenser machine.
+        /// </summary>
+        public List<DispenserLaneInformation> Lanes
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Information about the heads of this dispenser machine.
+        /// </summary>
+        public List<DispenserHeadInformation> Heads
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/Dispensing/DispenserHeadInformation.cs
+++ b/CFX/Structures/Dispensing/DispenserHeadInformation.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CFX.Structures.SMTPlacement;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CFX.Structures.Dispensing
+{
+  /// <summary>
+  /// Describes a head for an endpoint that is a dispensing machine.
+  /// </summary>
+  public class DispenserHeadInformation : HeadInformation
+  {
+    /// <summary>
+    /// Information about the dispensing valves mounted on the head
+    /// </summary>
+    public List<DispenserValveInformation> Valves
+    {
+      get;
+      set;
+    }
+  }
+}

--- a/CFX/Structures/Dispensing/DispenserLaneInformation.cs
+++ b/CFX/Structures/Dispensing/DispenserLaneInformation.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CFX.Structures.Dispensing
+{
+  /// <summary>
+  /// Describes a lane for an endpoint that is an dispensing machine.
+  /// </summary>
+  public class DispenserLaneInformation
+  {
+    /// <summary>
+    /// The lane number.  Corresponds with Lane property in production messages.
+    /// </summary>
+    public int? LaneNumber
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// The friendly name of this lane.
+    /// </summary>
+    public string LaneName
+    {
+      get;
+      set;
+    }
+
+    /// <summary>
+    /// The maximum and minimum dimensions that a PCB panel or fixture must conform
+    /// to in order to be processed by this lane.
+    /// </summary>
+    public DimensionalConstraints SupportedPCBDimensions
+    {
+      get;
+      set;
+    }
+  }
+}

--- a/CFX/Structures/Dispensing/DispenserValveInformation.cs
+++ b/CFX/Structures/Dispensing/DispenserValveInformation.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CFX.Structures.Dispensing
+{
+    /// <summary>
+    /// Describes a valve for an endpoint that is a dispensing machine.
+    /// </summary>
+    public class DispenserValveInformation
+      {
+        /// <summary>
+        /// A unique identifier describing this particular valve instance; Typically, this identifier is barcoded or otherwise labeled on the valve
+        /// </summary>
+        public string ValveId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A friendly name for this valve
+        /// </summary>
+        public string ValveName
+        {
+          get;
+          set;
+        }
+
+        /// <summary>
+        /// Sequence of this valve on the head
+        /// </summary>
+        public Int32 ValveSequence
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The type of the dispensing valve
+        /// </summary>
+        public DispenserValveType DispenserValveType
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/Dispensing/DispenserValveType.cs
+++ b/CFX/Structures/Dispensing/DispenserValveType.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CFX.Structures.Dispensing
+{
+  /// <summary>
+  /// An enumeration indicating different types of dispensing valves that might exist at an endpoint. 
+  /// If no valve is mounted on the head, the enumeration shall be set to “Undefined”.
+  /// </summary>
+  [JsonConverter(typeof(StringEnumConverter))]
+    public enum DispenserValveType
+    {
+        /// <summary>
+        /// Undefined valve type or no valve mounted on the head
+        /// </summary>
+        Undefined,
+        /// <summary>
+        /// Time-pressure valve type
+        /// </summary>
+        TimePressure,
+        /// <summary>
+        /// Auger valve type
+        /// </summary>
+        Auger,
+        /// <summary>
+        /// Piezo valve type
+        /// </summary>
+        Piezo,
+        /// <summary>
+        /// Pneumatic valve type
+        /// </summary>
+        Pneumatic,
+        /// <summary>
+        /// Volumetric valve type
+        /// </summary>
+        Volumetric
+  }
+}

--- a/CFX/Structures/Dispensing/DispensingFault.cs
+++ b/CFX/Structures/Dispensing/DispensingFault.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CFX.Structures.Dispensing
+{
+    /// <summary>
+    /// A specific type of fault that is produced by endpoints responsible for dispensing.
+    /// </summary>
+    public class DispensingFault : Fault
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public DispensingFault()
+        {
+            DispensingFaultType = DispensingFaultType.PickupError;
+            HeadAndValve = new HeadAndValve();
+            MaterialLocation = new MaterialLocation();
+        }
+
+        /// <summary>
+        /// The dispensing head and valve related to this fault (where applicable)
+        /// </summary>
+        public HeadAndValve HeadAndValve
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The material carrier location related to this fault (where applicable)
+        /// </summary>
+        public MaterialLocation MaterialLocation
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// A specific type of dispensing fault
+        /// </summary>
+        public DispensingFaultType DispensingFaultType
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/Dispensing/DispensingFaultType.cs
+++ b/CFX/Structures/Dispensing/DispensingFaultType.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace CFX.Structures.Dispensing
+{
+    /// <summary>
+    /// Types of SMT Placement Faults
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum DispensingFaultType
+    {
+        /// <summary>
+        /// Insufficient air pressure
+        /// </summary>
+        AirPressureError,
+        /// <summary>
+        /// Problem with the x motion axis
+        /// </summary>
+        XAxisError,
+        /// <summary>
+        /// Problem with the y motion axis
+        /// </summary>
+        YAxisError,
+        /// <summary>
+        /// Problem with the z motion axis
+        /// </summary>
+        ZAxisError,
+        /// <summary>
+        /// Position not dispensed
+        /// </summary>
+        DispensingError,
+        /// <summary>
+        /// Error with the dispensing valve
+        /// </summary>
+        ValveError,
+        /// <summary>
+        /// Error decoding fiducial reference mark
+        /// </summary>
+        FiducialError,
+        /// <summary>
+        /// Material supply will soon be exhausted
+        /// </summary>
+        MaterialLowQuantity,
+        /// <summary>
+        /// Material supply is exhausted
+        /// </summary>
+        MaterialExhausted,
+        /// <summary>
+        /// Error detecting the reference height
+        /// </summary>
+        HeightSensingError,
+        /// <summary>
+        /// Workstage temperature is out of the set range
+        /// </summary>
+        WorkstageTempertatureOutOfRange,
+        /// <summary>
+        /// Nozzle temperature is out of the set range
+        /// </summary>
+        NozzleTemperatureOutOfRange
+  }
+}

--- a/CFX/Structures/Dispensing/HeadAndValve.cs
+++ b/CFX/Structures/Dispensing/HeadAndValve.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CFX.Structures.Dispensing
+{
+    /// <summary>
+    /// Describes a particular valve and head combination that was used in the course of production.
+    /// </summary>
+    public class HeadAndValve : Tool
+    {
+        /// <summary>
+        /// The name or identifier of the head associated with this dispensing valve.
+        /// </summary>
+        public string HeadId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Sequence of this valve on the head
+        /// </summary>
+        public Int32 ValveSequence
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/Dispensing/ValveChangedActivity.cs
+++ b/CFX/Structures/Dispensing/ValveChangedActivity.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CFX.Structures.Dispensing
+{
+    /// <summary>
+    /// The activity describes the installation or removal or exchange of a dispensing valve.
+    /// </summary>
+    public class ValveChangedActivity : Activity
+    {
+        /// <summary>
+        /// The identifier of the head
+        /// </summary>
+        public string HeadId
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The valve which was removed from the head (if applicable)
+        /// </summary>
+        public DispenserValveInformation OldValve
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The valve which was installed on the head (if applicable)
+        /// </summary>
+        public DispenserValveInformation NewValve
+        {
+            get;
+            set;
+        }
+    }
+}


### PR DESCRIPTION
Introduce a new endpoint type “CFX.Structures.Dispensing” containing all relevant data for the application of materials (glue, solder paste, etc.), describing the specific machine parts (such as dispensing valves) and processes involved. 
Add dispensing data to relevant transactions.
Extend certain existing structures and enumerations with dispensing-specific data and values.

