### PR TITLE
CFX version is still 1.7 in the message envelope

### DIFF
--- a/CFX/CFXEnvelope.cs
+++ b/CFX/CFXEnvelope.cs
@@ -45,7 +45,7 @@ namespace CFX
             Transmitted = false;
         }
 
-        public const string CFXVERSION = "1.7";
+        public const string CFXVERSION = "2.0";
         
         public CFXEnvelope(Type messageType) : this()
         {


### PR DESCRIPTION
When sending a CFX message with the DLL in 2.0.2, the CFX version is still 1.7 in the envelope.