### PR TITLE
Downgrading AMQP.NET from 2.4.11 to 2.4.6

### DIFF
--- a/CFX/CFX.csproj
+++ b/CFX/CFX.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.4.11" />
+    <PackageReference Include="AMQPNetLite" Version="2.4.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/CFXExampleEndpoint/CFXExampleEndpoint.csproj
+++ b/CFXExampleEndpoint/CFXExampleEndpoint.csproj
@@ -102,7 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AMQPNetLite">
-      <Version>2.4.11</Version>
+      <Version>2.4.6</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.3</Version>


### PR DESCRIPTION
Downgrading AMQP.NET from 2.4.11 to 2.4.6 as it is causing issues in direct CFX requests, for some reason
Solving issue #235