### PR TITLE
Add handling logic for gzip encoding in AmqpUtilities.

### DIFF
--- a/CFX/CFX.csproj
+++ b/CFX/CFX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net8.0;netcoreapp3.1;net462</TargetFrameworks>
     <PackageId>CFX.CFXSDK</PackageId>
-    <PackageVersion>2.0.3</PackageVersion>
+    <PackageVersion>2.0.5</PackageVersion>
     <Authors>IPC CFX Committee</Authors>
     <Description>IPC Connected Factory Exchange Open Source Software Development Kit</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -17,9 +17,9 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/IPCConnectedFactoryExchange/CFX.git</RepositoryUrl>
     <PackageIcon>images/CFX_Logo.png</PackageIcon>
-    <Version>2.0.3</Version>
-    <AssemblyVersion>2.0.3.0</AssemblyVersion>
-    <FileVersion>2.0.3.0</FileVersion>
+    <Version>2.0.5</Version>
+    <AssemblyVersion>2.0.5.0</AssemblyVersion>
+    <FileVersion>2.0.5.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>CFXStrongNameKey.snk</AssemblyOriginatorKeyFile>
     <IncludeSymbols>true</IncludeSymbols>

--- a/CFX/Transport/AmqpUtilities.cs
+++ b/CFX/Transport/AmqpUtilities.cs
@@ -153,9 +153,13 @@ namespace CFX.Transport
 
         internal static string StringFromEnvelopes(Message msg)
         {
-            if (msg?.Body is byte[])
+            if (msg?.Body is byte[] array)
             {
-                return Encoding.UTF8.GetString(msg.Body as byte[]);
+                if (string.Equals(msg.Properties.ContentEncoding, "gzip", StringComparison.OrdinalIgnoreCase))
+                {
+                    array = Decode(array, CFXCodec.gzip);
+                }
+                return Encoding.UTF8.GetString(array);
             }
             else if (msg?.Body is string)
             {
@@ -257,6 +261,10 @@ namespace CFX.Transport
                 string result = "";
                 try
                 {
+                    if (string.Equals(message.Properties.ContentEncoding, "gzip", StringComparison.OrdinalIgnoreCase))
+                    {
+                        bt = Decode(bt, CFXCodec.gzip); ;
+                    }
                     result = Encoding.UTF8.GetString(bt);
                     if (result.Length > count) result = result.Substring(0, count);
                 }


### PR DESCRIPTION
The `OnMalformedMessageReceived` event does not currently handle gzip-compressed payloads. As a result, compressed messages may appear as garbled text, complicating debugging efforts.