### PR TITLE
Addition of missing rejection reasons in the case of an electrical test

### DIFF
--- a/CFX/Structures/RejectionReason.cs
+++ b/CFX/Structures/RejectionReason.cs
@@ -76,5 +76,25 @@ namespace CFX.Structures
         /// </summary>
 	    [CFX.Utilities.CreatedVersion("1.4")]
         BadVisionTestBeforePickup,
+        /// <summary>
+        /// The component was rejected because of a generic error detected after electrical test
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("2.1")]
+        ErrorAfterElectricalTest,
+        /// <summary>
+        /// The component was rejected because of a bad vision test after electrical test
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("2.1")]
+        BadVisionTestAfterElectricalTest,
+        /// <summary>
+        /// The component was rejected because of a bad pressure test after electrical test
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("2.1")]
+        BadPressureTestAfterElectricalTest,
+        /// <summary>
+        /// The component was rejected because of a bad optical test after electrical test
+        /// </summary>
+        [CFX.Utilities.CreatedVersion("2.1")]
+        BadOpticalTestAfterElectricalTest,
     }
 }


### PR DESCRIPTION
Since electrical testing of a component after it was picked can cause the component to shift or be lost, new vision/pressure/optical tests may be performed. We add these causes of rejection.