### PR TITLE
Add RecipeName to ValidateUnitsRequest

### DIFF
--- a/CFX/InformationSystem/UnitValidation/ValidateUnitsRequest.cs
+++ b/CFX/InformationSystem/UnitValidation/ValidateUnitsRequest.cs
@@ -117,5 +117,18 @@ namespace CFX.InformationSystem.UnitValidation
             get;
             set;
         }
+
+        /// <summary>
+        /// Currently loaded recipe name. Null if no specific recipe is currently loaded.
+        /// </summary>
+        /// <remarks>
+        /// Send the currently loaded recipe name as part of the request, so that the validation can be performed in the context of the current recipe.
+        /// </remarks>
+        [CFX.Utilities.CreatedVersion("2.1")]
+        public string RecipeName
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
Adds a new string property RecipeName to ValidateUnitsRequest (null if no recipe is loaded) so unit validation can be performed in the context of the currently loaded recipe. The property is annotated with [CFX.Utilities.CreatedVersion("2.1")] and includes XML documentation explaining its purpose.