### PR TITLE
Add GenericProcessData structure

### DIFF
--- a/CFX/Production/Processing/UnitsProcessed.cs
+++ b/CFX/Production/Processing/UnitsProcessed.cs
@@ -921,6 +921,110 @@ namespace CFX.Production.Processing
     ///    "UnitProcessData": []
     /// }
     /// </code>
+    /// <para></para>
+    /// <para>Example 8 (Generic Process Data - available in CFX 2.1 and later): suitable for
+    /// any equipment that does not have a dedicated ProcessData variant.  Reports setpoints,
+    /// readings, parameters, and optional per-stage data.</para>
+    /// <para></para>
+    /// <code language="none">
+    /// {
+    ///   "TransactionId": "c9a2b93b-1f0a-4d1a-9a9c-8b5f3e2d1c4b",
+    ///   "OverallResult": "Succeeded",
+    ///   "CommonProcessData": {
+    ///     "$type": "CFX.Structures.Generic.GenericProcessData, CFX",
+    ///     "Setpoints": [
+    ///       {
+    ///         "Name": "ConveyorSpeed",
+    ///         "Value": {
+    ///           "Value": 1.4,
+    ///           "ValueUnits": "m/min",
+    ///           "ExpectedValue": null,
+    ///           "ExpectedValueUnits": null,
+    ///           "MinimumAcceptableValue": null,
+    ///           "MinimumAcceptableValueUnits": null,
+    ///           "MaximumAcceptableValue": null,
+    ///           "MaximumAcceptableValueUnits": null
+    ///         }
+    ///       },
+    ///       {
+    ///         "Name": "CycleTime",
+    ///         "Value": {
+    ///           "Value": 45.0,
+    ///           "ValueUnits": "s",
+    ///           "ExpectedValue": null,
+    ///           "ExpectedValueUnits": null,
+    ///           "MinimumAcceptableValue": null,
+    ///           "MinimumAcceptableValueUnits": null,
+    ///           "MaximumAcceptableValue": null,
+    ///           "MaximumAcceptableValueUnits": null
+    ///         }
+    ///       }
+    ///     ],
+    ///     "Readings": [
+    ///       {
+    ///         "Name": "ActualCycleTime",
+    ///         "Value": {
+    ///           "Value": 45.6,
+    ///           "ValueUnits": "s",
+    ///           "ExpectedValue": 45.0,
+    ///           "ExpectedValueUnits": "s",
+    ///           "MinimumAcceptableValue": 43.0,
+    ///           "MinimumAcceptableValueUnits": "s",
+    ///           "MaximumAcceptableValue": 47.0,
+    ///           "MaximumAcceptableValueUnits": "s"
+    ///         }
+    ///       }
+    ///     ],
+    ///     "Parameters": [
+    ///       { "Name": "RecipeName", "Value": "RECIPE_42" },
+    ///       { "Name": "OperatorId", "Value": "BADGE489435" }
+    ///     ],
+    ///     "StageData": [
+    ///       {
+    ///         "Stage": {
+    ///           "StageSequence": 1,
+    ///           "StageName": "Stage1",
+    ///           "StageType": "Work"
+    ///         },
+    ///         "Setpoints": [
+    ///           {
+    ///             "Name": "HeaterTemperature",
+    ///             "Value": {
+    ///               "Value": 220.0,
+    ///               "ValueUnits": "Cel",
+    ///               "ExpectedValue": null,
+    ///               "ExpectedValueUnits": null,
+    ///               "MinimumAcceptableValue": null,
+    ///               "MinimumAcceptableValueUnits": null,
+    ///               "MaximumAcceptableValue": null,
+    ///               "MaximumAcceptableValueUnits": null
+    ///             }
+    ///           }
+    ///         ],
+    ///         "Readings": [
+    ///           {
+    ///             "Name": "ActualHeaterTemperature",
+    ///             "Value": {
+    ///               "Value": 221.3,
+    ///               "ValueUnits": "Cel",
+    ///               "ExpectedValue": 220.0,
+    ///               "ExpectedValueUnits": "Cel",
+    ///               "MinimumAcceptableValue": 215.0,
+    ///               "MinimumAcceptableValueUnits": "Cel",
+    ///               "MaximumAcceptableValue": 225.0,
+    ///               "MaximumAcceptableValueUnits": "Cel"
+    ///             }
+    ///           }
+    ///         ],
+    ///         "Parameters": [
+    ///           { "Name": "GasType", "Value": "Nitrogen" }
+    ///         ]
+    ///       }
+    ///     ]
+    ///   },
+    ///   "UnitProcessData": []
+    /// }
+    /// </code>
     /// </summary>
     [JsonObject(ItemTypeNameHandling = TypeNameHandling.Auto)]
     public class UnitsProcessed : CFXMessage

--- a/CFX/Structures/Generic/GenericProcessData.cs
+++ b/CFX/Structures/Generic/GenericProcessData.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CFX.Structures.Generic
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 2.1 **</para>
+    /// A flexible <see cref="ProcessData"/> variant suitable for a wide range of equipment
+    /// that does not have (or does not need) a dedicated process-specific structure.
+    /// <para></para>
+    /// Communicates three kinds of information captured during processing of a production
+    /// unit or a collection of units:
+    /// <list type="bullet">
+    /// <item><description><b>Setpoints</b> — single numeric values corresponding to configured
+    /// parameters of the equipment program (for example, the setpoint temperature of a
+    /// heater).</description></item>
+    /// <item><description><b>Readings</b> — measured numeric values captured during the
+    /// processing of a unit, optionally reported with ideal values and acceptable
+    /// limits.</description></item>
+    /// <item><description><b>Parameters</b> — other non-numerical information that needs to
+    /// be communicated, reported as name / string-value pairs.</description></item>
+    /// </list>
+    /// <para></para>
+    /// When the equipment has multiple stages and similar information is reported for each
+    /// stage, that per-stage information is reported in the <see cref="StageData"/> list,
+    /// which contains one <see cref="GenericStageData"/> entry per stage.
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("2.1")]
+    public class GenericProcessData : ProcessData
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public GenericProcessData()
+        {
+            Setpoints = new List<GenericValue>();
+            Readings = new List<GenericValue>();
+            Parameters = new List<GenericParameter>();
+            StageData = new List<GenericStageData>();
+        }
+
+        /// <summary>
+        /// The set of configured numeric setpoints that were active during processing
+        /// (for example, recipe-level setpoints that do not vary by stage).
+        /// </summary>
+        public List<GenericValue> Setpoints
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The set of numeric readings that were measured during processing
+        /// (for example, overall cycle time or whole-machine telemetry).
+        /// </summary>
+        public List<GenericValue> Readings
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Other non-numerical named parameters that were captured during processing
+        /// (communicated as name / string-value pairs).
+        /// </summary>
+        public List<GenericParameter> Parameters
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Optional list of per-stage process data, populated when the equipment has
+        /// multiple stages that each report their own setpoints, readings, and parameters.
+        /// </summary>
+        public List<GenericStageData> StageData
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/Generic/GenericStageData.cs
+++ b/CFX/Structures/Generic/GenericStageData.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CFX.Structures.Generic
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 2.1 **</para>
+    /// Represents the setpoints, readings, and parameters captured for a single stage
+    /// of a multi-stage process.  Used within the <see cref="GenericProcessData.StageData"/>
+    /// list when equipment reports similar process information for each stage.
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("2.1")]
+    public class GenericStageData
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public GenericStageData()
+        {
+            Setpoints = new List<GenericValue>();
+            Readings = new List<GenericValue>();
+            Parameters = new List<GenericParameter>();
+        }
+
+        /// <summary>
+        /// The stage of the equipment that this process data pertains to.
+        /// </summary>
+        public Stage Stage
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The set of configured numeric setpoints that were active during processing
+        /// at this stage (for example, zone temperature or fan speed setpoints).
+        /// </summary>
+        public List<GenericValue> Setpoints
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The set of numeric readings that were measured during processing at this stage
+        /// (for example, actual temperatures, pressures, or flow rates).
+        /// </summary>
+        public List<GenericValue> Readings
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Other non-numerical named parameters that were captured during processing
+        /// at this stage (communicated as name / string-value pairs).
+        /// </summary>
+        public List<GenericParameter> Parameters
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFX/Structures/Generic/GenericValue.cs
+++ b/CFX/Structures/Generic/GenericValue.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CFX.Structures.Generic
+{
+    /// <summary>
+    /// <para>** NOTE: ADDED in CFX 2.1 **</para>
+    /// A named numeric value used to represent either a setpoint or a reading within a
+    /// <see cref="GenericProcessData"/> structure.  When used as a setpoint, only the
+    /// <see cref="NumericValue.Value"/> and <see cref="NumericValue.ValueUnits"/> properties
+    /// are typically populated.  When used as a reading, the expected value and acceptable
+    /// range properties may also be populated.
+    /// </summary>
+    [CFX.Utilities.CreatedVersion("2.1")]
+    public class GenericValue
+    {
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public GenericValue()
+        {
+            Value = new NumericValue();
+        }
+
+        /// <summary>
+        /// A name that uniquely identifies this value within the containing process data
+        /// (for example, "HeaterTemperature", "ConveyorSpeed", "SpindleRPM").
+        /// </summary>
+        public string Name
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The numeric value along with its units and optional expected / minimum / maximum
+        /// acceptable values.
+        /// </summary>
+        public NumericValue Value
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/CFXExampleEndpoint/CFXExampleGenerator.cs
+++ b/CFXExampleEndpoint/CFXExampleGenerator.cs
@@ -42,6 +42,7 @@ using CFX.Structures.Validation;
 using CFX.InformationSystem.TopicValidation;
 using CFX.Structures.HandSoldering;
 using CFX.Structures.SolderWave;
+using CFX.Structures.Generic;
 
 namespace CFXExampleEndpoint
 {
@@ -3873,6 +3874,96 @@ namespace CFXExampleEndpoint
                     OffsetTheta= 2.5,
                     PrePrintStretch = 1,
                     PostPrintStretch = 1
+                },
+            };
+
+            AppendMessage(msg, ref result);
+
+            //New UnitsProcessed showing GenericProcessData usage
+            msg = new UnitsProcessed()
+            {
+                TransactionId = Guid.NewGuid(),
+                OverallResult = ProcessingResult.Succeeded,
+                CommonProcessData = new GenericProcessData()
+                {
+                    Setpoints = new List<GenericValue>(new GenericValue[]
+                    {
+                        new GenericValue()
+                        {
+                            Name = "ConveyorSpeed",
+                            Value = new NumericValue() { Value = 1.4, ValueUnits = "m/min" }
+                        },
+                        new GenericValue()
+                        {
+                            Name = "CycleTime",
+                            Value = new NumericValue() { Value = 45.0, ValueUnits = "s" }
+                        }
+                    }),
+                    Readings = new List<GenericValue>(new GenericValue[]
+                    {
+                        new GenericValue()
+                        {
+                            Name = "ActualCycleTime",
+                            Value = new NumericValue()
+                            {
+                                Value = 45.6,
+                                ValueUnits = "s",
+                                ExpectedValue = 45.0,
+                                ExpectedValueUnits = "s",
+                                MinimumAcceptableValue = 43.0,
+                                MinimumAcceptableValueUnits = "s",
+                                MaximumAcceptableValue = 47.0,
+                                MaximumAcceptableValueUnits = "s"
+                            }
+                        }
+                    }),
+                    Parameters = new List<GenericParameter>(new GenericParameter[]
+                    {
+                        new GenericParameter() { Name = "RecipeName", Value = "RECIPE_42" },
+                        new GenericParameter() { Name = "OperatorId", Value = "BADGE489435" }
+                    }),
+                    StageData = new List<GenericStageData>(new GenericStageData[]
+                    {
+                        new GenericStageData()
+                        {
+                            Stage = new Stage()
+                            {
+                                StageSequence = 1,
+                                StageName = "Stage1",
+                                StageType = StageType.Work
+                            },
+                            Setpoints = new List<GenericValue>(new GenericValue[]
+                            {
+                                new GenericValue()
+                                {
+                                    Name = "HeaterTemperature",
+                                    Value = new NumericValue() { Value = 220.0, ValueUnits = "Cel" }
+                                }
+                            }),
+                            Readings = new List<GenericValue>(new GenericValue[]
+                            {
+                                new GenericValue()
+                                {
+                                    Name = "ActualHeaterTemperature",
+                                    Value = new NumericValue()
+                                    {
+                                        Value = 221.3,
+                                        ValueUnits = "Cel",
+                                        ExpectedValue = 220.0,
+                                        ExpectedValueUnits = "Cel",
+                                        MinimumAcceptableValue = 215.0,
+                                        MinimumAcceptableValueUnits = "Cel",
+                                        MaximumAcceptableValue = 225.0,
+                                        MaximumAcceptableValueUnits = "Cel"
+                                    }
+                                }
+                            }),
+                            Parameters = new List<GenericParameter>(new GenericParameter[]
+                            {
+                                new GenericParameter() { Name = "GasType", Value = "Nitrogen" }
+                            })
+                        }
+                    })
                 },
             };
 


### PR DESCRIPTION
This adds support for basic equipment that just sends:
- setpoints: named numerical values that are set into the machine
- readings: measured numerical values (with name) and optionally limits
- parameters: named string value that wish to be communicated.

It removes the need to make a custom ProcessData structure for every possible type of equipment when a simplified format will suffice.